### PR TITLE
Define mergewith[!]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,17 +4,16 @@ uuid = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 version = "0.2.1"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Indexing = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [extras]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Compat", "Test"]
 
 [compat]
 julia = "1"
-Compat = "3.9"
 Indexing = "1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ uuid = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 version = "0.2.1"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Indexing = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
@@ -15,4 +16,5 @@ test = ["Test"]
 
 [compat]
 julia = "1"
+Compat = "3.9"
 Indexing = "1.1"

--- a/src/Dictionaries.jl
+++ b/src/Dictionaries.jl
@@ -15,6 +15,12 @@ export istokenizable, tokentype, tokens, tokenized, gettoken, gettokenvalue, ist
 
 export filterview # TODO move to SplitApplyCombine.jl (and re-order project dependencies?)
 
+if isdefined(Base, :mergewith)
+    import Base: mergewith, mergewith!
+else
+    import Compat: mergewith, mergewith!
+end
+
 include("AbstractDictionary.jl")
 include("AbstractIndices.jl")
 

--- a/src/Dictionaries.jl
+++ b/src/Dictionaries.jl
@@ -17,9 +17,9 @@ export filterview # TODO move to SplitApplyCombine.jl (and re-order project depe
 
 if isdefined(Base, :mergewith)
     import Base: mergewith, mergewith!
-else
-    import Compat: mergewith, mergewith!
 end
+# Otherwise, implement them as internal functions that are used for
+# `merge` and `merge!`.
 
 include("AbstractDictionary.jl")
 include("AbstractIndices.jl")

--- a/test/merge.jl
+++ b/test/merge.jl
@@ -1,0 +1,28 @@
+@testset "merge!" begin
+    d = dictionary('a':'c' .=> 1:3)
+    @test merge!(d, dictionary('a':'c' .=> 0)) === d
+    @test d == dictionary('a':'c' .=> 0)
+
+    d = dictionary('a':'c' .=> 1:3)
+    @test merge!(+, d, dictionary('a':'c' .=> 0)) === d
+    @test d == dictionary('a':'c' .=> 1:3)
+
+    d = dictionary('a':'c' .=> 1:3)
+    @test foldl(mergewith!((a, _) -> a + 1), dictionary.('a':'c' .=> 0); init = d) === d
+    @test d == dictionary('a':'c' .=> 2:4)
+end
+
+@testset "merge" begin
+    d = dictionary('a':'c' .=> 1:3)
+    @test merge(d, dictionary('a':'c' .=> 0)) == dictionary('a':'c' .=> 0)
+    @test d == dictionary('a':'c' .=> 1:3)
+
+    d = dictionary('a':'c' .=> 1:3)
+    @test merge(*, d, dictionary('a':'c' .=> 0)) == dictionary('a':'c' .=> 0)
+    @test d == dictionary('a':'c' .=> 1:3)
+
+    d = dictionary('a':'c' .=> 1:3)
+    @test foldl(mergewith((a, _) -> a + 1), dictionary.('a':'c' .=> 0); init = d) ==
+          dictionary('a':'c' .=> 2:4)
+    @test d == dictionary('a':'c' .=> 1:3)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test
+using Compat: mergewith, mergewith!
 using Dictionaries
 using Indexing
 
@@ -13,3 +14,4 @@ include("map.jl")
 include("broadcast.jl")
 include("filter.jl")
 include("find.jl")
+include("merge.jl")


### PR DESCRIPTION
This PR adds `mergewith!` and `mergewith` (and also `merge`).  It's kind of nice that we can use curried form like `mergewith!(+)` now. Some random example:

```julia
julia> mapfoldl(mergewith!(+), rand(1000) .* maxintfloat()) do x
           dictionary(digits(floor(Int, x))[end] => 1)
       end |> pairs |> collect |> sort!
9-element Array{Pair{Int64,Int64},1}:
 1 => 119
 2 => 126
 3 => 117
 4 => 142
 5 => 121
 6 => 119
 7 => 123
 8 => 114
 9 => 19
```
