### PR TITLE
Fix bug handling sizehint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 name = "Dictionaries"
 uuid = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Indexing = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -21,7 +21,7 @@ Indices(; sizehint = 8) = Indices{Any}(; sizehint = sizehint)
 
 function Indices{I}(; sizehint = 8) where {I}
     newsize = Base._tablesz((3 * sizehint) >> 0x01);
-    Indices{I}(fill(0, sizehint), Vector{UInt}(), Vector{I}(), 0)
+    Indices{I}(fill(0, newsize), Vector{UInt}(), Vector{I}(), 0)
 end
 
 """


### PR DESCRIPTION
Oops - the slots vector is meant to have length of a power of two. I had calculated the size appropriate to the sizehint but not used the result...

Fixes #37.