### PR TITLE
Remove reference to unimplemented function

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,6 @@ julia> dict .+ 1
  "c" │ 4
 ```
 
-There is a `mapview` function, which is the lazy version of the above.
-
 Filtering a dictionary also preserves the keys, dropping the remainder.
 
 ```julia


### PR DESCRIPTION
Hello! I was just getting to grips with this very cool package, working through the docs, and i noticed that the `mapview` function mentioned in the README isn't actually (yet?) implemented. Should it just be removed from the README for now? Should there be an issue about introducing such a function?

