### PR TITLE
Make it easier to handle shared indices, and add `empty_type` for new constructor patterns

### DIFF
--- a/src/AbstractDictionary.jl
+++ b/src/AbstractDictionary.jl
@@ -354,6 +354,10 @@ function Base.similar(indices::AbstractIndices{I}, ::Type{T}) where {I, T}
     return similar(convert(Indices{I}, indices), T)
 end
 
+# empty
+empty_type(::Type{<:AbstractDictionary}, ::Type{I}, ::Type{T}) where {I, T} = Dictionary{I, T}
+Base.empty(dict::AbstractDictionary, ::Type{I}, ::Type{T}) where {I, T} = empty_type(typeof(dict), I, T)()
+
 function Base.merge(d1::AbstractDictionary, d2::AbstractDictionary)
     # Note: need to copy the keys
     out = similar(copy(keys(d1)), eltype(d1))

--- a/src/AbstractIndices.jl
+++ b/src/AbstractIndices.jl
@@ -96,7 +96,8 @@ function Base.copy(inds::AbstractIndices, ::Type{I}) where I
     return out
 end
 
-Base.empty(::AbstractIndices, ::Type{I}) where {I} = Indices{I}()
+empty_type(::Type{<:AbstractIndices}, ::Type{I}) where {I} = Indices{I}
+Base.empty(inds::AbstractIndices, ::Type{I}) where {I} = empty_type(typeof(inds), I)()
 
 """
     distinct(itr)

--- a/src/ArrayDictionary.jl
+++ b/src/ArrayDictionary.jl
@@ -74,6 +74,8 @@ istokenizable(::ArrayDictionary) = true
 istokenassigned(d::ArrayDictionary, t::Int) = isassigned(parent(d), t)
 @propagate_inbounds gettokenvalue(d::ArrayDictionary, t::Int) = parent(d)[t]
 
+tokenized(dict::ArrayDictionary) = parent(dict)
+
 # settable interface
 issettable(::ArrayDictionary) = true # Need an array trait for this...
 
@@ -90,11 +92,7 @@ end
 isinsertable(::ArrayDictionary) = true # Need an array trait for this...
 
 @propagate_inbounds function gettoken!(d::ArrayDictionary{I}, i::I) where {I}
-    (hadtoken, token) = gettoken!(keys(d), i)
-    if !hadtoken
-        resize!(parent(d), length(parent(d)) + 1)
-    end
-    return (hadtoken, token)
+    gettoken!(keys(d), i, (parent(d),))
 end
 
 @propagate_inbounds function deletetoken!(d::ArrayDictionary, t::Int)
@@ -104,11 +102,8 @@ end
 end
 
 function Base.empty!(d::ArrayDictionary)
-    empty!(keys(d))
-    empty!(parent(d))
+    empty!(keys(d), (parent(d),))
     return d
 end
 
-function Base.empty(d::ArrayDictionary, ::Type{I}, ::Type{T}) where {I, T}
-    return ArrayDictionary(empty(keys(d), I), empty(parent(d), T))
-end
+empty_type(::Type{<:ArrayDictionary}, ::Type{I}, ::Type{T}) where {I, T} = ArrayDictionary{I, T, ArrayIndices{I, Vector{I}}, Vector{T}}

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -52,6 +52,10 @@ end
     return _f(d)(_gettokenvalue(t, _data(d)...)...)
 end
 
+@inline function Base.similar(d::BroadcastedDictionary, ::Type{T}) where {T}
+    return similar(_dicts(d.data...)[1], T)
+end
+
 @inline _dicts(d::AbstractDictionary, ds...) = (d, _dicts(ds...)...)
 @inline _dicts(d, ds...) = (_dicts(ds...)...,)
 _dicts() = ()

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -98,6 +98,7 @@ end
 
 Iterators.reverse(inds::FilteredIndices) = filterview(_pred(inds), Iterators.reverse(parent(inds)))
 
+empty_type(::Type{<:FilteredIndices{<:Any, Inds}}, ::Type{I}) where {I, Inds} = empty_type(Inds, I)
 
 function Base.isempty(inds::FilteredIndices)
     for _ in inds
@@ -192,5 +193,5 @@ function filterview(pred, inds::AbstractDictionary{I, T}) where {I, T}
     return FilteredDictionary{I, T, typeof(inds), typeof(pred)}(inds, pred)
 end
 
-Base.similar(dict::FilteredDictionary, ::Type{T}, indices) where {T} = similar(parent(dict), T, indices)
-Base.empty(dict::FilteredDictionary, ::Type{T}) where {T} = empty(parent(dict), T)
+Base.similar(dict::FilteredDictionary, ::Type{T}) where {T} = similar(parent(dict), T)
+empty_type(::Type{<:FilteredDictionary{<:Any, <:Any, D}}, ::Type{I}, ::Type{T}) where {I, T, D} = empty_type(D, I, T)

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -193,5 +193,5 @@ function filterview(pred, inds::AbstractDictionary{I, T}) where {I, T}
     return FilteredDictionary{I, T, typeof(inds), typeof(pred)}(inds, pred)
 end
 
-Base.similar(dict::FilteredDictionary, ::Type{T}) where {T} = similar(parent(dict), T)
+Base.similar(dict::FilteredDictionary, ::Type{T}) where {T} = similar(keys(dict), T)
 empty_type(::Type{<:FilteredDictionary{<:Any, <:Any, D}}, ::Type{I}, ::Type{T}) where {I, T, D} = empty_type(D, I, T)

--- a/src/insertion.jl
+++ b/src/insertion.jl
@@ -455,5 +455,3 @@ elements of type `eltype(inds)`.
 Base.empty(d::AbstractDictionary) = empty(keys(d), keytype(d), eltype(d))
 
 Base.empty(d::AbstractDictionary, ::Type{I}) where {I} = empty(keys(d), I)
-
-Base.empty(::AbstractDictionary, ::Type{I}, ::Type{T}) where {I, T} = Dictionary{I, T}()

--- a/src/map.jl
+++ b/src/map.jl
@@ -127,22 +127,21 @@ end
     return _f(d)(map(x -> @inbounds(x[i]), _dicts(d))...)::T
 end
 
-# TODO FIXME what do about tokens when there is more than one mapped dictioanry? For now, we disable them...
+# TODO FIXME what do about tokens when there is more than one mapped dictionary? For now, we disable them...
 istokenizable(d::MappedDictionary) = false
 function istokenizable(d::MappedDictionary{I, T, <:Any, <:Tuple{AbstractDictionary{<:I}}}) where {I, T}
     return istokenizable(_dicts(d)[1])
 end
 
 @propagate_inbounds function gettokenvalue(d::MappedDictionary{I, T, <:Any, <:Tuple{AbstractDictionary{<:I}}}, t) where {I, T}
-    return _f(d)(gettokenvalue(_dicts(d)[1], t))
+    return _f(d)(gettokenvalue(_dicts(d)[1], t))::T
 end
 
 function istokenassigned(d::MappedDictionary{I, T, <:Any, <:Tuple{AbstractDictionary{<:I}}}, t) where {I, T}
     return istokenassigned(_dicts(d)[1], t)
 end
 
-Base.similar(dict::MappedDictionary, ::Type{T}, indices) where {T} = similar(parent(dict), T, indices)
-Base.empty(dict::MappedDictionary, ::Type{I}, ::Type{T}) where {I, T} = similar(parent(dict), I, T)
+empty_type(::Type{<:MappedDictionary{<:Any, <:Any, <:Any, <:Tuple{D, Vararg{AbstractDictionary}}}}, ::Type{I}, ::Type{T}) where {I, T, D} = empty_type(D, I, T)
 
 if VERSION > v"1.6-"
     function Iterators.map(f, d::AbstractDictionary)

--- a/src/pairs.jl
+++ b/src/pairs.jl
@@ -53,4 +53,4 @@ iteratetoken(pd::PairDictionary, s...) = iteratetoken(parent(pd), s...)
 
 # Factories
 Base.similar(dict::PairDictionary, ::Type{T}, indices) where {T} = similar(parent(dict), T, indices)
-Base.empty(dict::PairDictionary, ::Type{I}, ::Type{T}) where {I, T} = similar(parent(dict), I, T)
+empty_type(::PairDictionary{<:Any, <:Any, D}, ::Type{I}, ::Type{T}) where {I, T, D} = similar(D, I, T)

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -21,8 +21,8 @@ Iterators.reverse(inds::ReverseIndices) = parent(inds)
 
 Base.reverse(inds::AbstractIndices) = copy(Iterators.reverse(inds))
 
-Base.empty(inds::ReverseIndices, ::Type{I}) where {I} = empty(parent(inds), I)
-Base.empty(inds::ReverseIndices, ::Type{I}, ::Type{T}) where {I, T} = empty(parent(inds), I, T)
+empty_type(::Type{<:ReverseIndices{<:Any, Inds}}, ::Type{I}) where {I, Inds} = empty_type(Inds, I)
+empty_type(::Type{<:ReverseIndices{<:Any, Inds}}, ::Type{I}, ::Type{T}) where {I, T, Inds} = empty_type(Inds, I, T)
 
 Base.similar(inds::ReverseIndices, ::Type{T}) where {T} = Iterators.reverse(similar(parent(inds), T))
 
@@ -56,5 +56,5 @@ function Base.reverse(dict::AbstractDictionary)
     return out
 end
 
-Base.empty(inds::ReverseDictionary, ::Type{I}) where {I} = empty(parent(inds), I)
-Base.empty(inds::ReverseDictionary, ::Type{I}, ::Type{T}) where {I, T} = empty(parent(inds), I, T)
+empty_type(::Type{<:ReverseDictionary{<:Any, <:Any, D}}, ::Type{I}) where {I, D} = empty_type(D, I)
+empty_type(::Type{<:ReverseDictionary{<:Any, <:Any, D}}, ::Type{I}, ::Type{T}) where {I, T, D} = empty_type(D, I, T)

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -87,7 +87,7 @@ istokenassigned(ts::IndicesTokens, t) = istokenassigned(parent(ts), t)
 gettokenvalue(ts::IndicesTokens, t) = t
 
 Base.IteratorSize(ts::IndicesTokens) = Base.IteratorSize(parent(ts))
-Base.length(ts::IndicesTokens) = Base.length(parent(ts))
+Base.length(ts::IndicesTokens) = length(parent(ts))
 
 """
     tokens(dict::AbstractDictionary)
@@ -196,6 +196,10 @@ end
     end
 
     return isassigned(d, token)
+end
+
+function istokenassigned(::AbstractIndices, token)
+    return true  # We are checking that given a valid token a value exists
 end
 
 @propagate_inbounds function settokenvalue!(d::AbstractDictionary{<:Any,T}, t, value) where {T}

--- a/test/ArrayIndices.jl
+++ b/test/ArrayIndices.jl
@@ -2,6 +2,7 @@
     @test ArrayIndices() isa ArrayIndices{Any}
 
     inds = ArrayIndices{Int64}()
+    @test ArrayIndices{Int64, Vector{Int64}}() == inds
 
     @test isinsertable(inds)
     @test length(inds) == 0
@@ -41,7 +42,10 @@
     delete!(inds, 10)
 
     @test isequal(inds, ArrayIndices{Int64}())
+    @test union!(inds, Indices([1,2,3,4])) == Indices([1, 2, 3, 4])
+    @test filter!(iseven, inds) == Indices([2, 4])
 
+    empty!(inds)
     for i = 2:2:100
         insert!(inds, i)
     end

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -165,6 +165,12 @@
 
     # TODO token interface
 
+    @testset "filter!" begin
+        d = Dictionary([1,2,3,4,5], [1,3,2,4,5])
+        filter!(iseven, d)
+        @test d == Dictionary([3,4], [2,4])
+    end
+
     @testset "Dict tests from Base" begin
         h = Dictionary{Int, Int}()
 

--- a/test/Indices.jl
+++ b/test/Indices.jl
@@ -1,5 +1,8 @@
 @testset "Indices" begin
     @test Indices() isa Indices{Any}
+    @test_throws IndexError Indices([1, 1])
+    @test @inferred(Indices(2*x for x in 1:10))::Indices == Indices(2:2:20)
+    @test @inferred(distinct(mod(x, 5) for x in 0:9))::Indices == Indices(0:4)
 
     h = Indices{Int64}()
 
@@ -77,6 +80,14 @@
         @test isless(i1, i4)
         @test !isless(i4, i1)
         @test !isequal(i1, i4)
+
+        @test cmp(i1, i1) == 0
+        @test cmp(i2, i1) == -1
+        @test cmp(i1, i2) == 1
+        @test cmp(i3, i1) == 1
+        @test cmp(i1, i3) == -1
+        @test cmp(i4, i1) == 1
+        @test cmp(i1, i4) == -1
 
         i5 = Indices([1,2,missing])
         @test isequal(i5, i5)

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -1,14 +1,24 @@
 @testset "filter" begin
-    i = Indices([1,2,3,4,5])
+    inds = Indices([1,2,3,4,5])
 
-    @test isequal(filter(iseven, i)::Indices, Indices([2, 4]))
-    @test isequal(filter(isodd, i)::Indices, Indices([1, 3, 5]))
+    @test isequal(filter(iseven, inds)::Indices, Indices([2, 4]))
+    @test isequal(filter(isodd, inds)::Indices, Indices([1, 3, 5]))
  
-    @test isequal(filterview(iseven, i)::Dictionaries.FilteredIndices, Indices([2, 4]))
-    @test isequal(filterview(isodd, i)::Dictionaries.FilteredIndices, Indices([1, 3, 5]))
+    @test isequal(filterview(iseven, inds)::Dictionaries.FilteredIndices, Indices([2, 4]))
+    @test isequal(filterview(isodd, inds)::Dictionaries.FilteredIndices, Indices([1, 3, 5]))
+    @test filterview(iseven, inds)[2] == 2
+    @test length(filterview(iseven, inds)) == 2
+    @test_throws IndexError filterview(isodd, inds)[2]
+    @test in(2, filterview(iseven, inds))
+    @test !in(2, filterview(isodd, inds))
 
-    filter!(iseven, i)
-    @test isequal(i, Indices([2, 4]))
+    @test collect(reverse(filterview(iseven, inds))) == [4, 2]
+
+    @test empty(filterview(iseven, inds))::Indices == Indices{Int}()
+    @test keys(similar(filterview(iseven, inds))::Dictionary) == Indices{Int}([2, 4])
+
+    filter!(iseven, inds)
+    @test isequal(inds, Indices([2, 4]))
 
     d = Dictionary([1,2,3,4,5], [1,3,2,4,5])
 
@@ -17,6 +27,12 @@
 
     @test isequal(filterview(iseven, d)::Dictionaries.FilteredDictionary, dictionary([3=>2, 4=>4]))
     @test isequal(filterview(isodd, d)::Dictionaries.FilteredDictionary, dictionary([1=>1, 2=>3, 5=>5]))
+    @test filterview(iseven, d)[3] == 2
+    @test length(filterview(iseven, d)) == 2
+    @test_throws IndexError filterview(isodd, d)[3]
+
+    @test empty(filterview(iseven, d))::Dictionary{Int, Int} == Dictionary{Int, Int}()
+    @test keys(similar(filterview(iseven, d))::Dictionary) == Indices{Int}([3, 4])
 
     filter!(iseven, d)
     @test isequal(d, Dictionary([3,4],[2,4]))

--- a/test/map.jl
+++ b/test/map.jl
@@ -8,17 +8,19 @@
 
     i = Indices([1,2,3,4,5])
 
-    @test issetequal(pairs(map(iseven, i)::Dictionary), [1=>false, 2=>true, 3=>false, 4=>true, 5=>false])
-    @test issetequal(pairs(map(isodd, i)::Dictionary), [1=>true, 2=>false, 3=>true, 4=>false, 5=>true])
+    @test map(iseven, i)::Dictionary == dictionary([1=>false, 2=>true, 3=>false, 4=>true, 5=>false])
+    @test map(isodd, i)::Dictionary == dictionary([1=>true, 2=>false, 3=>true, 4=>false, 5=>true])
  
-    @test issetequal(pairs(_mapview(iseven, i)::Dictionaries.MappedDictionary), [1=>false, 2=>true, 3=>false, 4=>true, 5=>false])
-    @test issetequal(pairs(_mapview(isodd, i)::Dictionaries.MappedDictionary), [1=>true, 2=>false, 3=>true, 4=>false, 5=>true])
+    @test _mapview(iseven, i)::Dictionaries.MappedDictionary == dictionary([1=>false, 2=>true, 3=>false, 4=>true, 5=>false])
+    @test _mapview(isodd, i)::Dictionaries.MappedDictionary == dictionary([1=>true, 2=>false, 3=>true, 4=>false, 5=>true])
 
     d = Dictionary([1,2,3,4,5], [1,3,2,4,5])
 
-    @test issetequal(pairs(map(iseven, d)::Dictionary), [1=>false, 2=>false, 3=>true, 4=>true, 5=>false])
-    @test issetequal(pairs(map(isodd, d)::Dictionary), [1=>true, 2=>true, 3=>false, 4=>false, 5=>true])
+    @test map(iseven, d)::Dictionary == dictionary([1=>false, 2=>false, 3=>true, 4=>true, 5=>false])
+    @test map(isodd, d)::Dictionary == dictionary([1=>true, 2=>true, 3=>false, 4=>false, 5=>true])
+    @test map(+, d, d)::Dictionary == dictionary([1=>2, 2=>6, 3=>4, 4=>8, 5=>10])
+    @test map(+, d, d, d)::Dictionary == dictionary([1=>3, 2=>9, 3=>6, 4=>12, 5=>15])
  
-    @test issetequal(pairs(_mapview(iseven, d)::Dictionaries.MappedDictionary), [1=>false, 2=>false, 3=>true, 4=>true, 5=>false])
-    @test issetequal(pairs(_mapview(isodd, d)::Dictionaries.MappedDictionary), [1=>true, 2=>true, 3=>false, 4=>false, 5=>true])
+    @test _mapview(iseven, d)::Dictionaries.MappedDictionary == dictionary([1=>false, 2=>false, 3=>true, 4=>true, 5=>false])
+    @test _mapview(isodd, d)::Dictionaries.MappedDictionary == dictionary([1=>true, 2=>true, 3=>false, 4=>false, 5=>true])
 end


### PR DESCRIPTION
Came across these during external work (SplitApplyCombine, TypedTables).

`empty_type` allows one to determine the type of a new container based on the type of an input container (and new key / element types). It should return a type `T` that is concrete, has the constructor method `T()`, and be `isinsertable` (remember that our `empty` methods behave more like `Base.emptymutable`), and is intended to be a type that is "similar" to the input type. It is used internally by `empty`.

The other changes make it easier to add or remove elements from multiple dictionaries that share common indices via `gettoken!`, `removetoken!` and `empty!`.

I think these patterns and interfaces will begin to settle over time, and then we can document them properly (though I think it would be good to consider sorted collections and possibly more esoteric dictionaries first).