### PR TITLE
Similar type

### DIFF
--- a/src/AbstractDictionary.jl
+++ b/src/AbstractDictionary.jl
@@ -348,18 +348,24 @@ end
     similar(d::AbstractDictionary, [T=eltype(d)])
 
 Construct a new `issettable` dictionary with identical `keys` as `d` and an element type of
-`T`. The initial values are3unitialized/undefined.
+`T`. The initial values are unitialized/undefined.
+
+The type of the returned dictionary is controlled by the `similar_type` function.
 """
 Base.similar(d::AbstractDictionary) = similar(keys(d), eltype(d))
 Base.similar(d::AbstractDictionary, ::Type{T}) where {T} = similar(keys(d), T)
 
-function Base.similar(indices::AbstractIndices{I}, ::Type{T}) where {I, T}
-    return similar(convert(Indices{I}, indices), T)
+function Base.similar(indices::AbstractIndices, ::Type{T}) where {T}
+    return similar_type(typeof(indices), T)(indices, undef)
 end
 
-# empty
-empty_type(::Type{<:AbstractDictionary}, ::Type{I}, ::Type{T}) where {I, T} = Dictionary{I, T}
-Base.empty(dict::AbstractDictionary, ::Type{I}, ::Type{T}) where {I, T} = empty_type(typeof(dict), I, T)()
+"""
+    similar_type(::Type{Inds}, ::Type{T}) where {Inds <: AbstractIndices, T}
+
+Return the type of an `issettable` dictionary with indices of a similar type to `Inds` and
+with values of type `T`.
+"""
+similar_type(::Type{<:AbstractIndices{I}}, ::Type{T}) where {I, T} = Dictionary{I, T}
 
 function Base.merge(d1::AbstractDictionary, d2::AbstractDictionary)
     # Note: need to copy the keys

--- a/src/AbstractIndices.jl
+++ b/src/AbstractIndices.jl
@@ -100,9 +100,6 @@ function Base.copy(inds::AbstractIndices, ::Type{I}) where I
     return out
 end
 
-empty_type(::Type{<:AbstractIndices}, ::Type{I}) where {I} = Indices{I}
-Base.empty(inds::AbstractIndices, ::Type{I}) where {I} = empty_type(typeof(inds), I)()
-
 """
     distinct(itr)
 

--- a/src/ArrayDictionary.jl
+++ b/src/ArrayDictionary.jl
@@ -50,6 +50,8 @@ Construct a `ArrayDictionary` from an iterable of `indices`, where the values ar
 undefined/uninitialized.
 """
 @propagate_inbounds ArrayDictionary{I, T}(inds, ::UndefInitializer) where {I, T} = ArrayDictionary{I, T}(ArrayIndices{I}(inds), undef)
+@propagate_inbounds ArrayDictionary(inds::ArrayIndices, ::UndefInitializer) = ArrayDictionary{eltype(inds), Any}(inds, undef)
+@propagate_inbounds ArrayDictionary{I}(inds::ArrayIndices{I}, ::UndefInitializer) where {I} = ArrayDictionary{I, Any}(inds, undef)
 @propagate_inbounds ArrayDictionary{I, T}(inds::ArrayIndices{I}, ::UndefInitializer) where {I, T} = ArrayDictionary{I, T}(inds, similar(parent(inds), T))
 
 """

--- a/src/Dictionary.jl
+++ b/src/Dictionary.jl
@@ -339,10 +339,3 @@ function Base.filter!(pred, dict::PairDictionary{<:Any, <:Any, <:Dictionary})
     _filter!(token -> pred(@inbounds gettokenvalue(indices, token) => gettokenvalue(d, token)), indices, (_values(d),))
     return dict
 end
-
-# Factories
-
-function Base.similar(indices::Indices{I}, ::Type{T}) where {I, T}
-    return Dictionary{I, T}(indices, Vector{T}(undef, length(_values(indices))), nothing)
-end
-

--- a/src/FillDictionary.jl
+++ b/src/FillDictionary.jl
@@ -17,3 +17,7 @@ Base.isassigned(d::FillDictionary{I}, i::I) where {I} = Base.isassigned(keys(d),
 gettokenvalue(d::FillDictionary, t) = getfield(d, :value)
 
 istokenassigned(d::FillDictionary, t) = true
+
+empty_type(::Type{<:FillDictionary{<:Any, <:Any, Inds}}, ::Type{I}) where {I, Inds} = empty_type(Inds, I)
+empty_type(::Type{<:FillDictionary{<:Any, <:Any, Inds}}, ::Type{I}, ::Type{T}) where {I, T, Inds} = empty_type(Inds, I, T)
+similar_type(::Type{<:FillDictionary{<:Any, <:Any, Inds}}, ::Type{T}) where {T, Inds} = similar_type(Inds, T)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -52,8 +52,31 @@ end
     return _f(d)(_gettokenvalue(t, _data(d)...)...)
 end
 
-@inline function Base.similar(d::BroadcastedDictionary, ::Type{T}) where {T}
-    return similar(_dicts(d.data...)[1], T)
+@generated function similar_type(::Type{<:BroadcastedDictionary{<:Any, <:Any, <:Any, Data}}, ::Type{T}) where {Data, T}
+    for D in Data.parameters
+        if D <: AbstractDictionary
+            return :(similar_type($D, T))
+        end
+    end
+    # should be unreachable
+end
+
+@generated function empty_type(::Type{<:BroadcastedDictionary{<:Any, <:Any, <:Any, Data}}, ::Type{I}) where {Data, I}
+    for D in Data.parameters
+        if D <: AbstractDictionary
+            return :(empty_type($D, I))
+        end
+    end
+    # should be unreachable
+end
+
+@generated function empty_type(::Type{<:BroadcastedDictionary{<:Any, <:Any, <:Any, Data}}, ::Type{I}, ::Type{T}) where {Data, I, T}
+    for D in Data.parameters
+        if D <: AbstractDictionary
+            return :(empty_type($D, I, T))
+        end
+    end
+    # should be unreachable
 end
 
 @inline _dicts(d::AbstractDictionary, ds...) = (d, _dicts(ds...)...)

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -98,7 +98,9 @@ end
 
 Iterators.reverse(inds::FilteredIndices) = filterview(_pred(inds), Iterators.reverse(parent(inds)))
 
+similar_type(::Type{<:FilteredIndices{<:Any, Inds}}, ::Type{T}) where {I, T, Inds} = similar_type(Inds, T)
 empty_type(::Type{<:FilteredIndices{<:Any, Inds}}, ::Type{I}) where {I, Inds} = empty_type(Inds, I)
+empty_type(::Type{<:FilteredIndices{<:Any, Inds}}, ::Type{I}, ::Type{T}) where {I, T, Inds} = empty_type(Inds, I, T)
 
 function Base.isempty(inds::FilteredIndices)
     for _ in inds
@@ -193,5 +195,6 @@ function filterview(pred, inds::AbstractDictionary{I, T}) where {I, T}
     return FilteredDictionary{I, T, typeof(inds), typeof(pred)}(inds, pred)
 end
 
-Base.similar(dict::FilteredDictionary, ::Type{T}) where {T} = similar(keys(dict), T)
+empty_type(::Type{<:FilteredDictionary{<:Any, <:Any, D}}, ::Type{I}) where {I, D} = empty_type(D, I)
 empty_type(::Type{<:FilteredDictionary{<:Any, <:Any, D}}, ::Type{I}, ::Type{T}) where {I, T, D} = empty_type(D, I, T)
+similar_type(::Type{<:FilteredDictionary{<:Any, <:Any, D}}, ::Type{T}) where {T, D} = similar_type(D, T)

--- a/src/insertion.jl
+++ b/src/insertion.jl
@@ -433,11 +433,16 @@ Return an empty, insertable `AbstractIndices` of element type `I` (even when the
 argument is a dictionary). The default container is `Indices{I}`, but the output may
 depend on the first argument.
 
+The type of the returned indices is controlled by the `empty_type` function.
+
     empty(inds::AbstractIndices)
 
 Return an empty, insertable `AbstractIndices` of element type `eltype(inds)`.
 """
 Base.empty(inds::AbstractIndices) = empty(inds, eltype(inds))
+Base.empty(inds::AbstractIndices, ::Type{I}) where {I} = empty_type(typeof(inds), I)()
+
+empty_type(::Type{<:AbstractIndices}, ::Type{I}) where {I} = Indices{I}
 
 """
     empty(inds::AbstractIndices, I::Type, T::Type)
@@ -447,11 +452,22 @@ Return an empty, insertable `AbstractDictionary` of with indices of type `I` and
 of type `T` (even when the first argument is are indices). The default container is
 `Dictionary{I}`, but the output may depend on the first argument.
 
+The type of the returned dictionary is controlled by the `empty_type` function.
+
     empty(dict::AbstractDictionary)
 
 Return an empty, insertable `AbstractDictionary` with indices of type `keytype(dict)` and
 elements of type `eltype(inds)`.
 """
 Base.empty(d::AbstractDictionary) = empty(keys(d), keytype(d), eltype(d))
-
 Base.empty(d::AbstractDictionary, ::Type{I}) where {I} = empty(keys(d), I)
+Base.empty(dict::AbstractDictionary, ::Type{I}, ::Type{T}) where {I, T} = empty(keys(dict), I, T)
+Base.empty(inds::AbstractIndices, ::Type{I}, ::Type{T}) where {I, T} = empty_type(typeof(inds), I, T)()
+
+"""
+    empty_type(::Type{Inds}, ::Type{I}, ::Type{T}) where {Inds <: AbstractIndices, I, T}
+
+Return the type of an `isinsertable` dictionary which is similar to type `Inds` and with
+keys of type `I` and values of type `T`.
+"""
+empty_type(::Type{<:AbstractIndices}, ::Type{I}, ::Type{T}) where {I, T} = Dictionary{I, T}

--- a/src/map.jl
+++ b/src/map.jl
@@ -141,7 +141,10 @@ function istokenassigned(d::MappedDictionary{I, T, <:Any, <:Tuple{AbstractDictio
     return istokenassigned(_dicts(d)[1], t)
 end
 
+empty_type(::Type{<:MappedDictionary{<:Any, <:Any, <:Any, <:Tuple{D, Vararg{AbstractDictionary}}}}, ::Type{I}) where {I, D} = empty_type(D, I)
 empty_type(::Type{<:MappedDictionary{<:Any, <:Any, <:Any, <:Tuple{D, Vararg{AbstractDictionary}}}}, ::Type{I}, ::Type{T}) where {I, T, D} = empty_type(D, I, T)
+
+similar_type(::Type{<:MappedDictionary{<:Any, <:Any, <:Any, <:Tuple{D, Vararg{AbstractDictionary}}}}, ::Type{T}) where {T, D} = similar_type(D, T)
 
 if VERSION > v"1.6-"
     function Iterators.map(f, d::AbstractDictionary)

--- a/src/pairs.jl
+++ b/src/pairs.jl
@@ -32,7 +32,6 @@ Base.keys(d::PairDictionary) = keys(parent(d))
 
 # Length
 Base.IteratorSize(d::PairDictionary) = Base.IteratorSize(parent(d))
-Base.length(d::PairDictionary) = Base.length(parent(d))
 
 # Standard interface
 @propagate_inbounds Base.getindex(d::PairDictionary{I}, i::I) where {I} = i => parent(d)[i]
@@ -52,5 +51,6 @@ istokenassigned(pd::PairDictionary, t) = istokenassigned(parent(pd), t)
 iteratetoken(pd::PairDictionary, s...) = iteratetoken(parent(pd), s...)
 
 # Factories
-Base.similar(dict::PairDictionary, ::Type{T}, indices) where {T} = similar(parent(dict), T, indices)
-empty_type(::PairDictionary{<:Any, <:Any, D}, ::Type{I}, ::Type{T}) where {I, T, D} = similar(D, I, T)
+empty_type(::PairDictionary{<:Any, <:Any, D}, ::Type{I}) where {I, D} = empty_type(D, I)
+empty_type(::PairDictionary{<:Any, <:Any, D}, ::Type{I}, ::Type{T}) where {I, T, D} = empty_type(D, I, T)
+similar_type(::PairDictionary{<:Any, <:Any, D}, ::Type{T}) where {I, T, D} = empty_type(D, T)

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -24,7 +24,7 @@ Base.reverse(inds::AbstractIndices) = copy(Iterators.reverse(inds))
 empty_type(::Type{<:ReverseIndices{<:Any, Inds}}, ::Type{I}) where {I, Inds} = empty_type(Inds, I)
 empty_type(::Type{<:ReverseIndices{<:Any, Inds}}, ::Type{I}, ::Type{T}) where {I, T, Inds} = empty_type(Inds, I, T)
 
-Base.similar(inds::ReverseIndices, ::Type{T}) where {T} = Iterators.reverse(similar(parent(inds), T))
+similar_type(::Type{<:ReverseIndices{<:Any, Inds}}, ::Type{T}) where {T, Inds} = similar_type(Inds, T) # TODO can we preserve the index?
 
 # Reversed dictionary
 struct ReverseDictionary{I, T, Dict <: AbstractDictionary{I, T}} <: AbstractDictionary{I, T}
@@ -58,3 +58,5 @@ end
 
 empty_type(::Type{<:ReverseDictionary{<:Any, <:Any, D}}, ::Type{I}) where {I, D} = empty_type(D, I)
 empty_type(::Type{<:ReverseDictionary{<:Any, <:Any, D}}, ::Type{I}, ::Type{T}) where {I, T, D} = empty_type(D, I, T)
+
+similar_type(::Type{<:ReverseDictionary{<:Any, <:Any, D}}, ::Type{T}) where {T, D} = similar_type(D, T) # TODO can we preserve the index?

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -66,6 +66,10 @@
     @test all(in(i, keys(d)) == iseven(i) for i in 2:2:100)
     @test isempty(empty!(d))
 
+    @test keys(ArrayDictionary([1, 2, 3], undef)::ArrayDictionary{Int, Any}) == Indices([1,2,3])
+    @test keys(ArrayDictionary{Int}([1, 2, 3], undef)::ArrayDictionary{Int, Any}) == Indices([1,2,3])
+    @test keys(ArrayDictionary{Int, String}([1, 2, 3], undef)::ArrayDictionary{Int, String}) == Indices([1,2,3])
+
     @testset "rand" begin
         dict = ArrayDictionary(["a", "b", "c", "d", "e"], 1:5)
         for i = 1:100

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -165,6 +165,10 @@
     #@test d[begin] == 1 # Parsing issues on earlier versions of Julia...
     @test d[end] == 2
 
+    @test keys(Dictionary([1, 2, 3], undef)::Dictionary{Int, Any}) == Indices([1,2,3])
+    @test keys(Dictionary{Int}([1, 2, 3], undef)::Dictionary{Int, Any}) == Indices([1,2,3])
+    @test keys(Dictionary{Int, String}([1, 2, 3], undef)::Dictionary{Int, String}) == Indices([1,2,3])
+
     # TODO token interface
 
     @testset "filter!" begin


### PR DESCRIPTION
This adds a new `similar_type` type-level function for giving the return type of `similar`. It is modelled similarly to `empty_type`. There are fixups for both `empty`, `similar` and the constructors.

There is an expectation that insertable containers have a zero-argument constructor (for constructing an empty container) and that settable dictionaries have a 2-argument constructor of the form `DictType(indices, undef)`.

In future I wish to add a third "factory" function like `empty` and `similar` for situations where both the keys and values are known. This is most useful for immutable dictionaries but the result does not have to be immutable - it's just a generic pattern for this case, that allow generic algorithms to be built uppon. Such dictionaries would have two-argument constructors of the form `DictType(indices, values)` and there would be a matching type-domain function. (Note: for indices there would be a single argument constructor of the form `IndType(indices)`).

CC @c42f - I'm thinking this "new" unimplement functionality is probably the "correct" way to do the StaticArrays pattern of `similar_type` and constructor requirements. I'm lost what to call it, though - placeholders for arguments sake would be `new(old_container, new_indices, new_values)` and `new_type(OldType, NewKeyType, NewElType)` but I'm not sure we can think of a better word than `new`? (Plus `new` wouldn't be callable from inner constructors, which would be a weird corner case to have).