### PR TITLE
Inidices with type-parameterized values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,18 @@
-authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 name = "Dictionaries"
 uuid = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
+authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 version = "0.3.10"
 
 [deps]
 Indexing = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[compat]
+Indexing = "1.1"
+julia = "1"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-
-[compat]
-julia = "1"
-Indexing = "1.1"

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -1,13 +1,13 @@
 const hash_mask = typemax(UInt) >>> 0x01
 const deletion_mask = hash_mask + 0x01
 
-mutable struct Indices{I} <: AbstractIndices{I}
+mutable struct Indices{I,V} <: AbstractIndices{I}
     # The hash table
     slots::Vector{Int}
 
     # Hashes and values
     hashes::Vector{UInt} # Deletion marker stored in high bit
-    values::Vector{I}
+    values::V
 
     holes::Int # Number of "vacant" slots in hashes and values
 end
@@ -80,7 +80,7 @@ function Indices{I}(iter) where {I}
     return Indices{I}(values)
 end
 
-function Indices{I}(values::Vector{I}) where {I}
+function Indices{I}(values::AbstractVector{I}) where {I}
     # The input must have unique elements (the constructor is not to be used in place of `distinct`)
     hashes = map(v -> hash(v) & hash_mask, values)
     

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -12,6 +12,10 @@ mutable struct Indices{I,V} <: AbstractIndices{I}
     holes::Int # Number of "vacant" slots in hashes and values
 end
 
+function Indices{I}(slots::Vector{Int}, hashes::Vector{UInt}, values::V, holes::Int) where {I,V} 
+    Indices{I,V}(slots, hashes, values, holes)
+end
+
 _slots(inds::Indices) = getfield(inds, :slots)
 _hashes(inds::Indices) = getfield(inds, :hashes)
 _values(inds::Indices) = getfield(inds, :values)
@@ -80,7 +84,7 @@ function Indices{I}(iter) where {I}
     return Indices{I}(values)
 end
 
-function Indices{I}(values::AbstractVector{I}) where {I}
+function Indices{I}(values::V) where {I, V<:AbstractVector{I}}
     # The input must have unique elements (the constructor is not to be used in place of `distinct`)
     hashes = map(v -> hash(v) & hash_mask, values)
     
@@ -106,7 +110,7 @@ function Indices{I}(values::AbstractVector{I}) where {I}
             # This is potentially an infinte loop and care must be taken not to overfill the container
         end
     end
-    return Indices{I}(slots, hashes, values, 0)
+    return Indices{I,V}(slots, hashes, values, 0)
 end
 
 Base.convert(::Type{AbstractIndices{I}}, inds::AbstractIndices) where {I} = convert(Indices{I}, inds) # the default AbstractIndices type

--- a/test/Indices.jl
+++ b/test/Indices.jl
@@ -16,7 +16,7 @@
     @test_throws IndexError h[10]
     @test length(unset!(h, 10)) == 0
     io = IOBuffer(); print(io, h); @test String(take!(io)) == "{}"
-    io = IOBuffer(); show(io, MIME"text/plain"(), h); @test String(take!(io)) == "0-element Indices{Int64}"
+    io = IOBuffer(); show(io, MIME"text/plain"(), h); @test String(take!(io)) == "0-element Indices{Int64, Vector{Int64}}"
     @test_throws IndexError delete!(h, 10)
 
     insert!(h, 10.0)
@@ -33,7 +33,7 @@
     @test length(set!(h, 10)) == 1
     @test_throws IndexError insert!(h, 10)
     io = IOBuffer(); print(io, h); @test String(take!(io)) == "{10}"
-    io = IOBuffer(); show(io, MIME"text/plain"(), h); @test String(take!(io)) == "1-element Indices{Int64}\n 10"
+    io = IOBuffer(); show(io, MIME"text/plain"(), h); @test String(take!(io)) == "1-element Indices{Int64, Vector{Int64}}\n 10"
     @test !isequal(h, empty(h))
     @test isequal(h, copy(h))
     @test isempty(empty(h))
@@ -184,7 +184,7 @@
         @test isequal(symdiff(i1, i3), Indices([1, 2, 3, 4]))
     end
 
-    @testset "covert" begin
+    @testset "convert" begin
         i = Indices{Int32}([1,2,3])
         ai = ArrayIndices{Int32}([1,2,3])
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -36,7 +36,7 @@
         @test show_str(filterview(iseven, Indices{Int64}(1:100))) == "Greater than 6-element FilteredIndices{Int64, Indices{Int64, UnitRange{Int64}}, typeof(iseven)}\n 2\n 4\n 6\n ⋮\n 98\n 100"
         if Int === Int64
             @test show_str(Indices{Vector{Int64}}([collect(1:100)])) == "1-element Indices{Vector{Int64}, Vector{Vector{Int64}}}\n [1, 2, 3, 4, 5, 6,…"
-            @test show_str(Indices{Vector{Int64}}([collect(1:(100+i)) for i in 1:100])) == "100-element Indices{Vector{Int64}}\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…\n ⋮\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…"
+            @test show_str(Indices{Vector{Int64}}([collect(1:(100+i)) for i in 1:100])) == "100-element Indices{Vector{Int64}, Vector{Vector{Int64}}}\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…\n ⋮\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…"
         else
             @test show_str(Indices{Vector{Int64}}([collect(1:100)])) == "1-element Indices{Vector{Int64}}\n Int64[1, 2, 3, 4, …"
             @test show_str(Indices{Vector{Int64}}([collect(1:(100+i)) for i in 1:100])) == "100-element Indices{Vector{Int64}}\n Int64[1, 2, 3, 4, …\n Int64[1, 2, 3, 4, …\n Int64[1, 2, 3, 4, …\n ⋮\n Int64[1, 2, 3, 4, …\n Int64[1, 2, 3, 4, …"

--- a/test/show.jl
+++ b/test/show.jl
@@ -30,12 +30,12 @@
             @test show_str(Dictionary{Vector{Int64},Vector{Int64}}([collect(1:100+i) for i in 1:100],[collect(101:200+i) for i in 1:100])) == "100-element Dictionary{Array{Int64,1},Array{Int64,1}}\n Int64[1… │ Int64[1…\n Int64[1… │ Int64[1…\n Int64[1… │ Int64[1…\n        ⋮ │ ⋮\n Int64[1… │ Int64[1…\n Int64[1… │ Int64[1…"
         end
     else
-        @test show_str(Indices{Int64}()) == "0-element Indices{Int64}"
-        @test show_str(Indices{Int64}(1:3)) == "3-element Indices{Int64}\n 1\n 2\n 3"
-        @test show_str(Indices{Int64}(1:100)) == "100-element Indices{Int64}\n 1\n 2\n 3\n ⋮\n 99\n 100"
-        @test show_str(filterview(iseven, Indices{Int64}(1:100))) == "Greater than 6-element FilteredIndices{Int64, Indices{Int64}, typeof(iseven)}\n 2\n 4\n 6\n ⋮\n 98\n 100"
+        @test show_str(Indices{Int64}()) == "0-element Indices{Int64, Vector{Int64}}"
+        @test show_str(Indices{Int64}(1:3)) == "3-element Indices{Int64, UnitRange{Int64}}\n 1\n 2\n 3"
+        @test show_str(Indices{Int64}(1:100)) == "100-element Indices{Int64, UnitRange{Int64}}\n 1\n 2\n 3\n ⋮\n 99\n 100"
+        @test show_str(filterview(iseven, Indices{Int64}(1:100))) == "Greater than 6-element FilteredIndices{Int64, Indices{Int64, UnitRange{Int64}}, typeof(iseven)}\n 2\n 4\n 6\n ⋮\n 98\n 100"
         if Int === Int64
-            @test show_str(Indices{Vector{Int64}}([collect(1:100)])) == "1-element Indices{Vector{Int64}}\n [1, 2, 3, 4, 5, 6,…"
+            @test show_str(Indices{Vector{Int64}}([collect(1:100)])) == "1-element Indices{Vector{Int64}, Vector{Vector{Int64}}}\n [1, 2, 3, 4, 5, 6,…"
             @test show_str(Indices{Vector{Int64}}([collect(1:(100+i)) for i in 1:100])) == "100-element Indices{Vector{Int64}}\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…\n ⋮\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…"
         else
             @test show_str(Indices{Vector{Int64}}([collect(1:100)])) == "1-element Indices{Vector{Int64}}\n Int64[1, 2, 3, 4, …"


### PR DESCRIPTION
This PR makes a small change to generalize `Indices`, replacing
```julia
mutable struct Indices{I} <: AbstractIndices{I}
    # The hash table
    slots::Vector{Int}

    # Hashes and values
    hashes::Vector{UInt} # Deletion marker stored in high bit
    values::Vector{I}

    holes::Int # Number of "vacant" slots in hashes and values
end
```
with
```julia
mutable struct Indices{I,V} <: AbstractIndices{I}
    # The hash table
    slots::Vector{Int}

    # Hashes and values
    hashes::Vector{UInt} # Deletion marker stored in high bit
    values::V

    holes::Int # Number of "vacant" slots in hashes and values
end
```

The idea is to allow values stored in other formats, for example a `StructArray` or `TupleVector`. I think this will be a step toward being able to implement something like
```julia
struct LogWeighted{I, T, V} <: AbstractDictionary{I, T}
    inds::Indices{I,V}

    # keys.data == inds.values
    keys::PermutedVector{V}

    logweights::Vector{T}
    logtotal::LogSumExp{T}

    function LogWeighted{I, T, V}(inds::Indices{I}, values::V, ::Nothing) where {I, T, V<:AbstractVector{T}}
       @assert length(values) == length(_values(inds))
       return new{I,T,V}(inds, values)
    end
end
```