### PR TITLE
Check hashes before values when getting Indices token

### DIFF
--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -313,16 +313,22 @@ function gettoken(indices::Indices{I}, i::I) where {I}
     full_hash = hash(i) & hash_mask
     n_slots = length(_slots(indices))
     bit_mask = n_slots - 1 # n_slots is always a power of two
+    hashes = indices.hashes
 
     trial_slot = reinterpret(Int, full_hash) & bit_mask
     @inbounds while true
         trial_slot = (trial_slot + 1)
         trial_index = _slots(indices)[trial_slot]
         if trial_index > 0
+            if !isbitstype(I) # this check is a compiletime constant
+                index_hash = @inbounds hashes[trial_index]
+                full_hash === index_hash || (@goto skipcheck)
+            end
             value = _values(indices)[trial_index]
             if i === value || isequal(i, value)
                 return (true, (trial_slot, trial_index))
-            end    
+            end
+            @label skipcheck
         elseif trial_index === 0
             return (false, (0, 0))
         end
@@ -349,6 +355,7 @@ function gettoken!(indices::Indices{I}, i::I, values = ()) where {I}
     n_slots = length(_slots(indices))
     bit_mask = n_slots - 1 # n_slots is always a power of two
     n_values = length(_values(indices))
+    hashes = indices.hashes
 
     trial_slot = reinterpret(Int, full_hash) & bit_mask
     trial_index = 0
@@ -363,10 +370,15 @@ function gettoken!(indices::Indices{I}, i::I, values = ()) where {I}
                 deleted_slot = trial_slot
             end
         else
+            if !isbitstype(I) # this check is a compiletime constant
+                index_hash = @inbounds hashes[trial_index]
+                full_hash === index_hash || (@goto skipcheck)
+            end
             value = _values(indices)[trial_index]
             if i === value || isequal(i, value)
                 return (true, (trial_slot, trial_index))
             end
+            @label skipcheck
         end
 
         trial_slot = trial_slot & bit_mask

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -320,15 +320,12 @@ function gettoken(indices::Indices{I}, i::I) where {I}
         trial_slot = (trial_slot + 1)
         trial_index = _slots(indices)[trial_slot]
         if trial_index > 0
-            if !isbitstype(I) # this check is a compiletime constant
-                index_hash = @inbounds hashes[trial_index]
-                full_hash === index_hash || (@goto skipcheck)
+            if isbitstype(I) || full_hash === @inbounds hashes[trial_index]
+                value = _values(indices)[trial_index]
+                if i === value || isequal(i, value)
+                    return (true, (trial_slot, trial_index))
+                end
             end
-            value = _values(indices)[trial_index]
-            if i === value || isequal(i, value)
-                return (true, (trial_slot, trial_index))
-            end
-            @label skipcheck
         elseif trial_index === 0
             return (false, (0, 0))
         end
@@ -370,15 +367,12 @@ function gettoken!(indices::Indices{I}, i::I, values = ()) where {I}
                 deleted_slot = trial_slot
             end
         else
-            if !isbitstype(I) # this check is a compiletime constant
-                index_hash = @inbounds hashes[trial_index]
-                full_hash === index_hash || (@goto skipcheck)
+            if isbitstype(I) || full_hash === @inbounds hashes[trial_index]
+                value = _values(indices)[trial_index]
+                if i === value || isequal(i, value)
+                    return (true, (trial_slot, trial_index))
+                end
             end
-            value = _values(indices)[trial_index]
-            if i === value || isequal(i, value)
-                return (true, (trial_slot, trial_index))
-            end
-            @label skipcheck
         end
 
         trial_slot = trial_slot & bit_mask

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -320,7 +320,7 @@ function gettoken(indices::Indices{I}, i::I) where {I}
         trial_slot = (trial_slot + 1)
         trial_index = _slots(indices)[trial_slot]
         if trial_index > 0
-            if isbitstype(I) || full_hash === @inbounds hashes[trial_index]
+            if isbitstype(I) || Base.isbitsunion(I) || I === Symbol || full_hash === @inbounds hashes[trial_index]
                 value = _values(indices)[trial_index]
                 if i === value || isequal(i, value)
                     return (true, (trial_slot, trial_index))
@@ -367,7 +367,7 @@ function gettoken!(indices::Indices{I}, i::I, values = ()) where {I}
                 deleted_slot = trial_slot
             end
         else
-            if isbitstype(I) || full_hash === @inbounds hashes[trial_index]
+            if isbitstype(I) || Base.isbitsunion(I) || I === Symbol || full_hash === @inbounds hashes[trial_index]
                 value = _values(indices)[trial_index]
                 if i === value || isequal(i, value)
                     return (true, (trial_slot, trial_index))


### PR DESCRIPTION
Fix #58
Honestly, the gains are pretty modest - like 10% speed improvement. I guess the speed improvement can be arbitrarily high if you cherry pick objects that take a really long time to compare - I picked short strings, as that's probably most representative.