### PR TITLE
Ensure broadcasted functions retain their bounds checks

### DIFF
--- a/test/auto_boundscheck.jl
+++ b/test/auto_boundscheck.jl
@@ -1,0 +1,21 @@
+using Dictionaries
+using Test
+
+# The following tests are run without the --bounds-check option.
+
+# Issue #63 - Broadcasting only omitted bounds check due to inbounds propagation
+@static if VERSION < v"1.4" # Duplicate of Base implementation
+    Base.@propagate_inbounds function only(x)
+        i = iterate(x)
+        @boundscheck if i === nothing
+            throw(ArgumentError("Collection is empty, must contain exactly 1 element"))
+        end
+        (ret, state) = i
+        @boundscheck if iterate(x, state) !== nothing
+            throw(ArgumentError("Collection has multiple elements, must contain exactly 1 element"))
+        end
+        return ret
+    end
+end
+d3 = Dictionary([:a, :b], [[1,2], [3,4]])
+@test_throws ArgumentError only.(d3)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -28,4 +28,21 @@
     @test isequal(d2, dictionary([1=>4, 2=>6, 3=>8, 4=>10, 5=>12]))
 
     @test_throws IndexError Dictionary([1,2],[1,2]) .+ Dictionary([2,3],[2,3])
+
+    # Issue #63 - Broadcasting only omitted bounds check due to inbounds propagation
+    if VERSION < v"1.4" # Compat
+        Base.@propagate_inbounds function only(x)
+            i = iterate(x)
+            @boundscheck if i === nothing
+                throw(ArgumentError("Collection is empty, must contain exactly 1 element"))
+            end
+            (ret, state) = i
+            @boundscheck if iterate(x, state) !== nothing
+                throw(ArgumentError("Collection has multiple elements, must contain exactly 1 element"))
+            end
+            return ret
+        end
+    end
+    d2 = Dictionary([:a, :b], [[1,2], [3,4]])
+    @test_throws ArgumentError only.(d2)
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -28,21 +28,4 @@
     @test isequal(d2, dictionary([1=>4, 2=>6, 3=>8, 4=>10, 5=>12]))
 
     @test_throws IndexError Dictionary([1,2],[1,2]) .+ Dictionary([2,3],[2,3])
-
-    # Issue #63 - Broadcasting only omitted bounds check due to inbounds propagation
-    if VERSION < v"1.4" # Compat
-        Base.@propagate_inbounds function only(x)
-            i = iterate(x)
-            @boundscheck if i === nothing
-                throw(ArgumentError("Collection is empty, must contain exactly 1 element"))
-            end
-            (ret, state) = i
-            @boundscheck if iterate(x, state) !== nothing
-                throw(ArgumentError("Collection has multiple elements, must contain exactly 1 element"))
-            end
-            return ret
-        end
-    end
-    d2 = Dictionary([:a, :b], [[1,2], [3,4]])
-    @test_throws ArgumentError only.(d2)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,3 +16,8 @@ include("filter.jl")
 include("find.jl")
 include("reverse.jl")
 include("show.jl")
+
+# Run the following test without julia --check-bounds=yes mode
+cmd = deepcopy(Base.julia_cmd())
+filter!(a->!startswith(a, "--check-bounds="), cmd.exec)
+@test process_exited(run(`$cmd auto_boundscheck.jl`))


### PR DESCRIPTION
The inbounds assertion within the map! implementation, combined with
propagate_inbounds on gettokenvalue(d::BroadcastedDictionary, t) leads
to removing the bound check on any user-defined function which is
broadcasted. This adds an extra layer of dispatch to protect the
user-defined function which is broadcasted.

Fixes #63 