### PR TITLE
use `sizehint` for hash and value arrays as well

### DIFF
--- a/src/Dictionary.jl
+++ b/src/Dictionary.jl
@@ -26,7 +26,9 @@ Dictionary(; sizehint = 8) = Dictionary{Any, Any}(; sizehint = sizehint)
 Dictionary{I}(; sizehint = 8) where {I} = Dictionary{I, Any}(; sizehint = sizehint)
 
 function Dictionary{I, T}(; sizehint = 8) where {I, T}
-    Dictionary{I, T}(Indices{I}(; sizehint = sizehint), Vector{T}(), nothing)
+    values = Vector{T}()
+    sizehint!(values, sizehint)
+    Dictionary{I, T}(Indices{I}(; sizehint = sizehint), values, nothing)
 end
 
 """

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -21,7 +21,11 @@ Indices(; sizehint = 8) = Indices{Any}(; sizehint = sizehint)
 
 function Indices{I}(; sizehint = 8) where {I}
     newsize = Base._tablesz((3 * sizehint) >> 0x01);
-    Indices{I}(fill(0, newsize), Vector{UInt}(), Vector{I}(), 0)
+    hashes = Vector{UInt}()
+    values = Vector{I}()
+    sizehint!(hashes, sizehint)
+    sizehint!(values, sizehint)
+    Indices{I}(fill(0, newsize), hashes, values, 0)
 end
 
 """


### PR DESCRIPTION
This seemed sensible enough to me and helped performance a little in my
case.
