### PR TITLE
Fix invariance of `convert` for `Dictionary`

### DIFF
--- a/src/Dictionary.jl
+++ b/src/Dictionary.jl
@@ -157,6 +157,7 @@ end
 function Base.convert(::Type{Dictionary{I, T}}, dict::Dictionary) where {I, T}
     return Dictionary{I, T}(convert(Indices{I}, dict.indices), convert(Vector{T}, dict.values))
 end
+Base.convert(::Type{T}, dict::T) where {T<:Dictionary} = dict
 
 """
     dictionary(iter)

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -157,6 +157,8 @@
 
     d7 = Dictionary(Int32[1, 2], UInt32[1, 2])
     @test convert(Dictionary{Int64, Int64}, d7)::Dictionary{Int64, Int64} == Dictionary(Int64[1, 2], Int64[1, 2])
+    d8 = Dictionary{Int,Int}()
+    @test convert(Dictionary{Int,Int}, d8) === d8
 
     rd = Dictionary([:b, :a], [2, 1])
     @test reverse(d)::Dictionary == rd


### PR DESCRIPTION
Adding the `convert` method from #67 seems to have broken `convert(::Type{T}, x::T) = x`, which led to problems because the identity of a given dictionary was not maintained.