### PR TITLE
Fix undefined values after sorting

### DIFF
--- a/src/Dictionary.jl
+++ b/src/Dictionary.jl
@@ -366,12 +366,13 @@ function Base.sort!(dict::Dictionary; kwargs...)
         rehash!(inds, length(inds.slots))
     end
     perm = sortperm(dict.values; kwargs...)
+    iperm = invperm(perm)
     inds.values = @inbounds inds.values[perm]
     inds.hashes = @inbounds inds.hashes[perm]
     @inbounds for i in keys(inds.slots)
         s = inds.slots[i]
         if s > 0
-            inds.slots[i] = perm[s]
+            inds.slots[i] = iperm[s]
         end
     end
     permute!(dict.values, perm)
@@ -392,12 +393,13 @@ function sortkeys!(dict::Dictionary; kwargs...)
         rehash!(inds, length(inds.slots))
     end
     perm = sortperm(inds.values; kwargs...)
+    iperm = invperm(perm)
     inds.values = @inbounds inds.values[perm]
     inds.hashes = @inbounds inds.hashes[perm]
     @inbounds for i in keys(inds.slots)
         s = inds.slots[i]
         if s > 0
-            inds.slots[i] = perm[s]
+            inds.slots[i] = iperm[s]
         end
     end
     permute!(dict.values, perm)
@@ -420,12 +422,13 @@ function sortpairs!(dict::Dictionary; by = identity, kwargs...)
     vals = dict.values
     inds_vals = inds.values
     perm = sortperm(keys(dict.values); by = i -> by(@inbounds(inds_vals[i]) => @inbounds(vals[i])), kwargs...)
+    iperm = invperm(perm)
     inds.values = @inbounds inds.values[perm]
     inds.hashes = @inbounds inds.hashes[perm]
     @inbounds for i in keys(inds.slots)
         s = inds.slots[i]
         if s > 0
-            inds.slots[i] = perm[s]
+            inds.slots[i] = iperm[s]
         end
     end
     permute!(dict.values, perm)

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -299,29 +299,36 @@
         dictcopy = deepcopy(dict)
         sort!(dictcopy)
         @test dictcopy == Dictionary([3, 2, 1], ['a', 'b', 'c'])
-        
+        @test all(isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
+
         dictcopy = deepcopy(dict)
         sort!(dictcopy; rev = true)
         @test dictcopy == Dictionary([1, 2, 3], ['c', 'b', 'a'])
+        @test all(isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
 
         dictcopy = deepcopy(dict)
         sortkeys!(dictcopy)
         @test dictcopy == Dictionary([1, 2, 3], ['c', 'b', 'a'])
+        @test all(isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
 
         dictcopy = deepcopy(dict)
         sortkeys!(dictcopy; rev = true)
         @test dictcopy == Dictionary([3, 2, 1], ['a', 'b', 'c'])
+        @test all(isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
 
         dictcopy = deepcopy(dict)
         sortpairs!(dictcopy)
         @test dictcopy == Dictionary([1, 2, 3], ['c', 'b', 'a'])
+        @test all(isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
 
         dictcopy = deepcopy(dict)
         sortpairs!(dictcopy; rev = true)
         @test dictcopy == Dictionary([3, 2, 1], ['a', 'b', 'c'])
+        @test all(isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
 
         dictcopy = deepcopy(dict)
         sortpairs!(dictcopy; by = kv->kv.second=>kv.first)
         @test dictcopy == Dictionary([3, 2, 1], ['a', 'b', 'c'])
+        @test all(isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
     end
 end


### PR DESCRIPTION
I stumbled upon a similar case to this one:
```julia
julia>         dict = Dictionary([1, 3, 2], ['c', 'a', 'b'])
3-element Dictionary{Int64, Char}
 1 │ 'c'
 3 │ 'a'
 2 │ 'b'

julia> sort!(dict)
3-element Dictionary{Int64, Char}
 3 │ #undef
 2 │ #undef
 1 │ #undef
```

Because the equality between `Dictionary` is defined pairwise, and that

```julia
julia> collect(pairs(dict))
3-element Vector{Pair{Int64, Char}}:
 3 => 'a'
 2 => 'b'
 1 => 'c'
 ```
 
 this particular issue was not caught in tests. The following fixes should make it work correctly for all mutating sorts (see the added tests) for `Dictionary`.