### PR TITLE
Add `copy` definition for `Dictionary` that works with `undef`

### DIFF
--- a/src/ArrayDictionary.jl
+++ b/src/ArrayDictionary.jl
@@ -90,6 +90,8 @@ function Base.similar(inds::ArrayIndices, ::Type{T}) where {T}
     return ArrayDictionary(inds, similar(parent(inds), T))
 end
 
+Base.copy(dict::ArrayDictionary) = ArrayDictionary(dict.indices, copy(dict.values))
+
 # insertable interface
 isinsertable(::ArrayDictionary) = true # Need an array trait for this...
 

--- a/src/ArrayDictionary.jl
+++ b/src/ArrayDictionary.jl
@@ -9,7 +9,7 @@ If `indices` and `values` are `Vector`s, then the result is `isinsertable` and
 optimal for small collections.
 """
 struct ArrayDictionary{I, T, Inds <: ArrayIndices{I}, Vals <: AbstractArray{T}} <: AbstractDictionary{I, T}
-	indices::Inds
+    indices::Inds
     values::Vals
     
     @inline function ArrayDictionary{I, T, Indices, Values}(indices::Indices, values::Values) where {I, T, Indices <: ArrayIndices{I}, Values <: AbstractArray{T}}
@@ -64,6 +64,8 @@ Construct a `ArrayDictionary` from an indexable container `indexable` with the s
 ArrayDictionary(indexable) = ArrayDictionary(keys(indexable), values(indexable))
 ArrayDictionary{I}(indexable) where {I} = ArrayDictionary{I}(keys(indexable), values(indexable))
 ArrayDictionary{I, T}(indexable) where {I, T} = ArrayDictionary{I, T}(keys(indexable), values(indexable))
+
+ArrayDictionary{I, T}(indexable::ArrayDictionary) where {I, T} = ArrayDictionary{I, T, ArrayIndices{I}, Vector{T}}(convert(ArrayIndices{I}, keys(indexable)), convert(Vector{T}, indexable.values))
 
 Base.parent(d::ArrayDictionary) = getfield(d, :values)
 

--- a/src/Dictionary.jl
+++ b/src/Dictionary.jl
@@ -170,6 +170,8 @@ function Base.convert(::Type{Dictionary{I, T}}, dict::Dictionary) where {I, T}
 end
 Base.convert(::Type{T}, dict::T) where {T<:Dictionary} = dict
 
+Base.copy(dict::Dictionary) = Dictionary(dict.indices, copy(dict.values))
+
 """
     dictionary(iter)
 

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -80,7 +80,7 @@
         @test dict isa ArrayDictionary{Int, String}
         @test sharetokens(dict, dictcopy)
         if VERSION < v"1.6-"
-            io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element ArrayDictionary{Int64,String,ArrayIndices{Int64,Vector{Int64}},Vector{String}}\n 1 │ #undef\n 2 │ #undef"
+            io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element ArrayDictionary{Int64,String,ArrayIndices{Int64,Array{Int64,1}},Array{String,1}}\n 1 │ #undef\n 2 │ #undef"
         else
             io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element ArrayDictionary{Int64, String, ArrayIndices{Int64, Vector{Int64}}, Vector{String}}\n 1 │ #undef\n 2 │ #undef"
         end

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -77,7 +77,7 @@
         dict = ArrayDictionary{Int64, String}([1, 2], undef)
 
         dictcopy = copy(dict)
-        @test dict isa ArrayDictionary{Int, String}
+        @test dict isa ArrayDictionary{Int64, String}
         @test sharetokens(dict, dictcopy)
         if VERSION < v"1.6-"
             io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element ArrayDictionary{Int64,String,ArrayIndices{Int64,Array{Int64,1}},Array{String,1}}\n 1 │ #undef\n 2 │ #undef"

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -79,7 +79,11 @@
         dictcopy = copy(dict)
         @test dict isa ArrayDictionary{Int, String}
         @test sharetokens(dict, dictcopy)
-        io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element ArrayDictionary{Int64, String, ArrayIndices{Int64, Vector{Int64}}, Vector{String}}\n 1 │ #undef\n 2 │ #undef"
+        if VERSION < v"1.6-"
+            io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element ArrayDictionary{Int64,String,ArrayIndices{Int64,Vector{Int64}},Vector{String}}\n 1 │ #undef\n 2 │ #undef"
+        else
+            io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element ArrayDictionary{Int64, String, ArrayIndices{Int64, Vector{Int64}}, Vector{String}}\n 1 │ #undef\n 2 │ #undef"
+        end
         @test all(!isassigned(dict, i) for i in collect(keys(dict)))
         @test all(!isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
         @test sharetokens(dict, ArrayDictionary{Int64, String}(dict))

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -74,7 +74,7 @@
     end
 
     @testset "copy" begin
-        dict = ArrayDictionary{Int, String}([1, 2], undef)
+        dict = ArrayDictionary{Int64, String}([1, 2], undef)
 
         dictcopy = copy(dict)
         @test dict isa ArrayDictionary{Int, String}

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -73,6 +73,19 @@
         end
     end
 
+    @testset "copy" begin
+        dict = ArrayDictionary{Int, String}([1, 2], undef)
+
+        dictcopy = copy(dict)
+        @test dict isa ArrayDictionary{Int, String}
+        @test sharetokens(dict, dictcopy)
+        io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element ArrayDictionary{Int64, String, ArrayIndices{Int64, Vector{Int64}}, Vector{String}}\n 1 │ #undef\n 2 │ #undef"
+        @test all(!isassigned(dict, i) for i in collect(keys(dict)))
+        @test all(!isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
+        @test sharetokens(dict, ArrayDictionary{Int64, String}(dict))
+        @test pairs(dict) isa Dictionaries.PairDictionary{Int64, String}
+    end
+
     @testset "sort" begin
         dict = ArrayDictionary([1, 3, 2], ['c', 'a', 'b'])
         @test sort(dict)::ArrayDictionary == ArrayDictionary([3, 2, 1], ['a', 'b', 'c'])

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -170,6 +170,17 @@
     #@test d[begin] == 1 # Parsing issues on earlier versions of Julia...
     @test d[end] == 2
 
+    dict = Dictionary{Int, String}([1, 2], undef)
+
+    dictcopy = copy(dict)
+    @test dict isa Dictionary{Int, String}
+    @test sharetokens(dict, dictcopy)
+    io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element Dictionary{Int64, String}\n 1 │ #undef\n 2 │ #undef"
+    @test all(!isassigned(dict, i) for i in collect(keys(dict)))
+    @test all(!isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
+    @test sharetokens(dict, Dictionary{Int64, String}(dict))
+    @test pairs(dict) isa Dictionaries.PairDictionary{Int64, String}
+
     # TODO token interface
 
     @testset "filter!" begin

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -170,7 +170,7 @@
     #@test d[begin] == 1 # Parsing issues on earlier versions of Julia...
     @test d[end] == 2
 
-    dict = Dictionary{Int, String}([1, 2], undef)
+    dict = Dictionary{Int64, String}([1, 2], undef)
 
     dictcopy = copy(dict)
     @test dict isa Dictionary{Int, String}

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -157,8 +157,8 @@
 
     d7 = Dictionary(Int32[1, 2], UInt32[1, 2])
     @test convert(Dictionary{Int64, Int64}, d7)::Dictionary{Int64, Int64} == Dictionary(Int64[1, 2], Int64[1, 2])
-    d8 = Dictionary{Int,Int}()
-    @test convert(Dictionary{Int,Int}, d8) === d8
+    d8 = Dictionary{Int, Int}()
+    @test convert(Dictionary{Int ,Int}, d8) === d8
 
     rd = Dictionary([:b, :a], [2, 1])
     @test reverse(d)::Dictionary == rd
@@ -173,7 +173,7 @@
     dict = Dictionary{Int64, String}([1, 2], undef)
 
     dictcopy = copy(dict)
-    @test dict isa Dictionary{Int, String}
+    @test dict isa Dictionary{Int64, String}
     @test sharetokens(dict, dictcopy)
     if VERSION < v"1.6-"
         io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element Dictionary{Int64,String}\n 1 │ #undef\n 2 │ #undef"

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -175,7 +175,11 @@
     dictcopy = copy(dict)
     @test dict isa Dictionary{Int, String}
     @test sharetokens(dict, dictcopy)
-    io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element Dictionary{Int64, String}\n 1 │ #undef\n 2 │ #undef"
+    if VERSION < v"1.6-"
+        io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element Dictionary{Int64,String}\n 1 │ #undef\n 2 │ #undef"
+    else
+        io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element Dictionary{Int64, String}\n 1 │ #undef\n 2 │ #undef"
+    end
     @test all(!isassigned(dict, i) for i in collect(keys(dict)))
     @test all(!isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
     @test sharetokens(dict, Dictionary{Int64, String}(dict))


### PR DESCRIPTION
Add `copy` definition for `Dictionary` that works with `undef`. Also add some tests for operations on `Dictionary` with `undef` elements.

@andyferris, let me know if you have another way you would prefer to define this. The previous definition forwarded to `copyto!`, which forwarded to `map!`, which threw and error if the elements of the `Dictionary` are `undef`:
```julia
julia> dict = Dictionary{Int, String}([1, 2], undef)
2-element Dictionary{Int64, String}
 1 │ #undef
 2 │ #undef

julia> copy(dict)
ERROR: UndefRefError: access to undefined reference
Stacktrace:
 [1] getindex
   @ ./array.jl:861 [inlined]
 [2] gettokenvalue
   @ ~/.julia/dev/Dictionaries/src/Dictionary.jl:308 [inlined]
 [3] map!(f::typeof(identity), out::Dictionary{Int64, String}, d::Dictionary{Int64, String})
   @ Dictionaries ~/.julia/packages/Dictionaries/sMIv4/src/map.jl:57
 [4] copyto!
   @ ~/.julia/dev/Dictionaries/src/AbstractDictionary.jl:493 [inlined]
 [5] copy
   @ ~/.julia/dev/Dictionaries/src/AbstractDictionary.jl:488 [inlined]
 [6] copy(dict::Dictionary{Int64, String})
   @ Dictionaries ~/.julia/packages/Dictionaries/sMIv4/src/AbstractDictionary.jl:485
 [7] top-level scope
   @ REPL[7]:1
```
The advantage of the previous approach is that it could work for a generic `AbstractDictionary`, which is still available as a generic fallback.