### PR TITLE
remove convertability requirement in get

### DIFF
--- a/src/ArrayIndices.jl
+++ b/src/ArrayIndices.jl
@@ -82,7 +82,7 @@ end
     end
 end
 
-@inline function gettoken(inds::ArrayIndices{I}, i::I) where {I}
+@inline function gettoken(inds::ArrayIndices, i)
     a = parent(inds)
     @inbounds for x in LinearIndices(a)
         if isequal(i, a[x])

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -313,7 +313,7 @@ end
     return nothing
 end
 
-function gettoken(indices::Indices{I}, i::I) where {I}
+function gettoken(indices::Indices{I}, i) where {I}
     full_hash = hash(i) & hash_mask
     n_slots = length(_slots(indices))
     bit_mask = n_slots - 1 # n_slots is always a power of two

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -44,7 +44,7 @@ function tokens(d::BroadcastedDictionary)
     _tokens(_data(d)...)
 end
 
-@propagate_inbounds function gettoken(d::BroadcastedDictionary{I}, i::I) where {I}
+@propagate_inbounds function gettoken(d::BroadcastedDictionary, i)
     return gettoken(_tokens(_data(d)...), i)
 end
 

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -83,7 +83,7 @@ end
     end
     return nothing
 end
-@propagate_inbounds function gettoken(inds::FilteredIndices{I}, i::I) where {I}
+@propagate_inbounds function gettoken(inds::FilteredIndices, i)
     (hastoken, token) = gettoken(parent(inds), i)
     @boundscheck if hastoken
         return (_pred(inds)(@inbounds gettokenvalue(parent, token)), token)
@@ -179,7 +179,7 @@ end
 # These dictionaries are not settable - changing the values can change the keys
 
 istokenizable(dict::FilteredDictionary) = istokenizable(parent(dict))
-@propagate_inbounds function gettoken(dict::FilteredDictionary{I}, i::I) where {I}
+@propagate_inbounds function gettoken(dict::FilteredDictionary, i)
     (hastoken, token) = gettoken(parent(dict), i)
     @boundscheck if hastoken
         return (_pred(dict)(@inbounds gettokenvalue(parent, token)), token)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -16,11 +16,7 @@ end
 end
 
 ## `get` helper function
-@propagate_inbounds function Base.get(d::AbstractDictionary{I, T}, i, default) where {I, T}
-    get(d, convert(I, i), default)
-end
-
-@propagate_inbounds function Base.get(d::AbstractDictionary{I}, i::I, default) where {I}
+@propagate_inbounds function Base.get(d::AbstractDictionary, i, default)
     (hasindex, t) = gettoken(d, i)
     if hasindex
         return gettokenvalue(d, t)
@@ -29,11 +25,7 @@ end
     end
 end
 
-@propagate_inbounds function Base.get(f::Base.Callable, d::AbstractDictionary{I}, i) where {I}
-    get(f, d, convert(I, i))
-end
-
-@propagate_inbounds function Base.get(f::Base.Callable, d::AbstractDictionary{I, T}, i::I) where {I, T}
+@propagate_inbounds function Base.get(f::Base.Callable, d::AbstractDictionary, i)
     (hasindex, t) = gettoken(d, i)
     if hasindex
         return gettokenvalue(d, t)
@@ -97,7 +89,7 @@ end
 end
 
 # `DictionaryView` shares tokens with it's `keys` (and can co-iterate quickly with other dictionaries with those keys)
-@propagate_inbounds function gettoken(d::DictionaryView{I}, i::I) where {I}
+@propagate_inbounds function gettoken(d::DictionaryView, i)
     return gettoken(_inds(d), i)
 end
 

--- a/src/pairs.jl
+++ b/src/pairs.jl
@@ -40,7 +40,7 @@ Base.isassigned(d::PairDictionary{I}, i::I) where {I} = isassigned(parent(d), i)
 
 
 # Token interface
-@propagate_inbounds gettoken(d::PairDictionary{I}, i::I) where {I} = gettoken(parent(d), i)
+@propagate_inbounds gettoken(d::PairDictionary, i) = gettoken(parent(d), i)
 
 @propagate_inbounds function gettokenvalue(pd::PairDictionary, t)
     d = parent(pd)

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -10,7 +10,7 @@ Base.IteratorSize(inds::ReverseIndices) = Base.IteratorSize(parent(inds))
 
 istokenizable(inds::ReverseIndices) = istokenizable(parent(inds))
 tokentype(inds::ReverseIndices) = tokentype(parent(inds))
-@propagate_inbounds gettoken(inds::ReverseIndices{I}, i::I) where {I} = gettoken(parent(inds), i)
+@propagate_inbounds gettoken(inds::ReverseIndices, i) = gettoken(parent(inds), i)
 @propagate_inbounds gettokenvalue(inds::ReverseIndices, t) = gettokenvalue(parent(inds), t)
 
 @propagate_inbounds iteratetoken(inds::ReverseIndices, s...) = iteratetoken_reverse(parent(inds), s...)

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -83,7 +83,7 @@ tokentype(::IndicesTokens{<:Any, T}) where {T} = T
 tokens(ts::IndicesTokens) = ts
 istokenassigned(ts::IndicesTokens, t) = istokenassigned(parent(ts), t)
 @propagate_inbounds iteratetoken(ts::IndicesTokens, s...) = iteratetoken(parent(ts), s...)
-@propagate_inbounds gettoken(ts::IndicesTokens{I}, i::I) where {I} = gettoken(parent(ts), i)
+@propagate_inbounds gettoken(ts::IndicesTokens, i) = gettoken(parent(ts), i)
 gettokenvalue(ts::IndicesTokens, t) = t
 
 Base.IteratorSize(ts::IndicesTokens) = Base.IteratorSize(parent(ts))
@@ -163,7 +163,7 @@ Settable (i.e. mutable) dictionaries allow you to set a corresponding value via 
 
 Insertable dictionaries provide the `gettoken!` function (see the `isinsertable` trait).
 """
-@propagate_inbounds function gettoken(inds::AbstractIndices{I}, i::I) where I
+@propagate_inbounds function gettoken(inds::AbstractIndices, i)
     if istokenizable(inds)
         error("gettoken needs to be defined for tokenizable indices: $(typeof(inds))")
     end
@@ -174,12 +174,8 @@ Insertable dictionaries provide the `gettoken!` function (see the `isinsertable`
     return (true, i)
 end
 
-@propagate_inbounds function gettoken(d::AbstractDictionary{I}, i::I) where I
+@propagate_inbounds function gettoken(d::AbstractDictionary, i)
     return gettoken(keys(d), i)
-end
-
-@propagate_inbounds function gettoken(d::AbstractDictionary{I}, i) where I
-    return gettoken(d, convert(I, i))
 end
 
 @propagate_inbounds function gettokenvalue(d::AbstractDictionary, token)

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -12,6 +12,9 @@
     @test isequal(copy(d), d)
     @test_throws IndexError d[10]
     @test get(d, 10, 15) == 15
+    @test get(() -> 15, d, 10) == 15
+    @test get(d, "10", 15) == 15
+    @test get(() -> 15, d, "10") == 15
     @test length(unset!(d, 10)) == 0
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{}"
     if VERSION < v"1.6-"
@@ -28,6 +31,9 @@
     @test haskey(d, 10)
     @test !haskey(d, 100)
     @test get(d, 10, 15) == 11
+    @test get(() -> 15, d, 10) == 11
+    @test get(d, "10", 15) == 15
+    @test get(() -> 15, d, "10") == 15
     @test get!(d, 10, 15) == 11
     @test length(d) == 1
     @test keys(d) === keys(keys(d))

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -25,6 +25,9 @@
     @test cmp(Dictionary(copy(keys(d)), d), d) == 0
     @test_throws IndexError d[10]
     @test get(d, 10, 15) == 15
+    @test get(() -> 15, d, 10) == 15
+    @test get(d, "10", 15) == 15
+    @test get(() -> 15, d, "10") == 15
     @test length(unset!(d, 10)) == 0
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{}"
     if VERSION < v"1.6-"
@@ -41,6 +44,9 @@
     @test haskey(d, 10)
     @test !haskey(d, 100)
     @test get(d, 10, 15) == 11
+    @test get(() -> 15, d, 10) == 11
+    @test get(d, "10", 15) == 15
+    @test get(() -> 15, d, "10") == 15
     @test get!(d, 10, 15) == 11
     @test length(d) == 1
     @test keys(d) === keys(keys(d))


### PR DESCRIPTION
Fix #92. This makes the interface

```julia
function gettoken(dict::AbstractDictionary, token) end
```

and removes the need for conversion. The conversion is kept for modifying methods (such as `get!`), as in that case one needs to be able to add the index. This is consistent with how Julia Base does it, see eg [get!](https://github.com/JuliaLang/julia/blob/master/base/dict.jl#L468) (with conversion) and [get](https://github.com/JuliaLang/julia/blob/master/base/dict.jl#L523) (without conversion).