### PR TITLE
Enable set operations between `AbstractIndices` and abitrary itr

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 name = "Dictionaries"
 uuid = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
-version = "0.3.20"
+version = "0.3.21"
 
 [deps]
 Indexing = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"

--- a/src/insertion.jl
+++ b/src/insertion.jl
@@ -3,14 +3,14 @@
 
 Return `true` if `dict` supports the insertable interface, or `false` otherwise. The primary
 functions `dict` needs to implement for the insertable interface are:
- 
+
  * `insert!(dict, i, value)` - add a new `value` at index `i` (will error if index exists)
  * `delete!(dict, i)` - remove element at index `i` (will error if index does not exist)
 
 Functions `get!`, `set!` and `unset!` are also provided for common operations where you are
 not sure if an index exists or not. New insertable dictionaries are primarily generated via
 the `empty` function.
-    
+
 See also `issettable` and `istokenizable`.
 """
 isinsertable(::AbstractDictionary) = false
@@ -20,7 +20,7 @@ isinsertable(::AbstractDictionary) = false
 
 Return `true` if `indices` supports the insertable interface, or `false` otherwise. The
 primary functions a map needs to implement for the insertable interface are:
- 
+
  * `insert!(indices, i)` - add new index `i` to `indices` (will error if index exists)
  * `delete!(indices, i)` - remove an existing index `i` from `indices` (will error if index does not exist).
 
@@ -112,7 +112,7 @@ end
     insert!(dict::AbstractDictionary, i, value)
 
 Insert the `value` at new index `i` into `dict`. An error is thrown if index `i` already
-exists. 
+exists.
 
 Hint: Use `setindex!` to update an existing value, and `set!` to perform an "upsert"
 (update-or-insert) operation.
@@ -368,18 +368,18 @@ function Base.union!(s1::AbstractIndices, itr)
     return s1
 end
 
-function Base.intersect!(s1::AbstractIndices, s2::AbstractIndices)
+function Base.intersect!(s1::AbstractIndices, s2)
     return filter!(in(s2), s1)
 end
 
-function Base.setdiff!(s1::AbstractIndices, s2::AbstractIndices)
+function Base.setdiff!(s1::AbstractIndices, s2)
     for i in s2
         unset!(s1, i)
     end
     return s1
 end
 
-function Base.symdiff!(s1::AbstractIndices, s2::AbstractIndices)
+function Base.symdiff!(s1::AbstractIndices, s2)
     for i in s2
         (hastoken, token) = gettoken!(s1, i)
         if hastoken
@@ -393,7 +393,7 @@ end
 
 # These generic implementations are gimped.
 
-# # `filter!` is basically a programmatic version of `intersect!`. 
+# # `filter!` is basically a programmatic version of `intersect!`.
 # function Base.filter!(pred, indices::AbstractIndices)
 #     for i in copy(indices)
 #         if !pred(i)

--- a/test/Indices.jl
+++ b/test/Indices.jl
@@ -158,6 +158,8 @@
         i3 = Indices([3,4])
         i4 = Indices([2])
 
+        s1 = [4,5]
+
         @test !issetequal(i1, i2)
         @test !(i1 ⊆ i2)
         @test i4 ⊆ i1
@@ -169,19 +171,23 @@
             @test !isdisjoint(i1, i2)
             @test isdisjoint(i1, i3)
         end
-        
+
         @test isequal(union(i1, i2), Indices([1,2,3]))
         @test isequal(union(i2, i1), Indices([2,3,1]))
         @test isequal(union(i1, i3), Indices([1,2,3,4]))
+        @test isequal(union(i1, s1), Indices([1,2,4,5]))
 
         @test isequal(intersect(i1, i2), Indices([2]))
         @test isequal(intersect(i1, i3), Indices([]))
+        @test isequal(intersect(i3, s1), Indices([4]))
 
         @test isequal(setdiff(i1, i2), Indices([1]))
         @test isequal(setdiff(i1, i3), Indices([1, 2]))
+        @test isequal(setdiff(i3, s1), Indices([3]))
 
         @test isequal(symdiff(i1, i2), Indices([1, 3]))
         @test isequal(symdiff(i1, i3), Indices([1, 2, 3, 4]))
+        @test isequal(symdiff(i3, s1), Indices([3, 5]))
     end
 
     @testset "covert" begin
@@ -193,7 +199,7 @@
 
         @test convert(Indices{Int32}, i) === i
         @test convert(Indices{Int64}, i)::Indices{Int64} == i
-        
+
         @test convert(Indices{Int32}, ai)::Indices{Int32} == i
         @test convert(Indices{Int64}, ai)::Indices{Int64} == i
     end


### PR DESCRIPTION
Relaxes the types on the mutating methods of set operations so as to match the dispatch pattern in `Base`.  This means that set operations where the first argument is `<:AbstractIndices` and the second is any valid `itr` will return an `Indices` with the result.

Fix for https://github.com/andyferris/Dictionaries.jl/issues/100