### PR TITLE
Working `deepcopy` for `Dictionary` and `UnorderedDictionary`

### DIFF
--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -184,6 +184,10 @@ function Base.copy(indices::ReverseIndices{I,Indices{I}}, ::Type{I2}) where {I, 
     return Indices{I2}(new_slots, reverse(_hashes(p)), collect(I2, Iterators.reverse(_values(p))), _holes(p))
 end
 
+function Base.deepcopy_internal(ind::Indices{T}, id::IdDict) where {T}
+    return Indices{T}(Base.deepcopy_internal(ind.values, id))
+end
+
 # private (note that newsize must be power of two)
 function rehash!(indices::Indices{I}, newsize::Int, values = (), include_last_values::Bool = true) where {I}
     slots = resize!(_slots(indices), newsize)

--- a/src/UnorderedIndices.jl
+++ b/src/UnorderedIndices.jl
@@ -73,6 +73,10 @@ function Base.copy(h::UnorderedIndices{T}, ::Type{T}) where {T}
     return UnorderedIndices{T}(copy(h.slots), copy(h.inds), h.ndel, h.count, h.idxfloor, h.maxprobe)
 end
 
+function Base.deepcopy_internal(uinds::UnorderedIndices{T}, id::IdDict) where {T}
+    return UnorderedIndices{T}(Base.deepcopy_internal(uinds.inds, id))
+end
+
 ## Length
 Base.length(h::UnorderedIndices) = h.count
 

--- a/src/UnorderedIndices.jl
+++ b/src/UnorderedIndices.jl
@@ -74,7 +74,7 @@ function Base.copy(h::UnorderedIndices{T}, ::Type{T}) where {T}
 end
 
 function Base.deepcopy_internal(uinds::UnorderedIndices{T}, id::IdDict) where {T}
-    return UnorderedIndices{T}(Base.deepcopy_internal(uinds.inds, id))
+    return UnorderedIndices{T}(Base.deepcopy_internal(collect(keys(uinds)), id))
 end
 
 ## Length

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -145,6 +145,9 @@
     @test !isdictequal(Dictionary(['a','b'],[1,2]), Dictionary(['b','c'],[2,1]))
     @test !isdictequal(Dictionary(['a','b'],[1,2]), Dictionary(['a','b','c'],[1,2,3]))
     @test !isdictequal(Dictionary(['a','b'],[1,2]), Dictionary(['b','a'],[2,3]))
+
+    dmutable = deepcopy(Dictionary([Foo(3), Foo(2)], rand(2)))
+    @test all(k -> haskey(dmutable, k), keys(dmutable))
     
     d5 = Dictionary(['a','b'],[1,missing])
     @test isdictequal(d5, d5) === missing

--- a/test/UnorderedDictionary.jl
+++ b/test/UnorderedDictionary.jl
@@ -110,6 +110,9 @@
     @test !isdictequal(UnorderedDictionary(['a','b'],[1,2]), UnorderedDictionary(['b','c'],[2,1]))
     @test !isdictequal(UnorderedDictionary(['a','b'],[1,2]), UnorderedDictionary(['a','b','c'],[1,2,3]))
     @test !isdictequal(UnorderedDictionary(['a','b'],[1,2]), UnorderedDictionary(['b','a'],[2,3]))
+
+    dmutable = deepcopy(UnorderedDictionary([Foo(3), Foo(2)], rand(2)))
+    @test all(k -> haskey(dmutable, k), keys(dmutable))
     
     d5 = UnorderedDictionary(['a','b'],[1,missing])
     @test isdictequal(d5, d5) === missing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,22 +7,24 @@ mutable struct Foo{T}
     x::T
 end
 
-include("Indices.jl")
-include("Dictionary.jl")
-include("ArrayIndices.jl")
-include("ArrayDictionary.jl")
-include("PairDictionary.jl")
-include("FillDictionary.jl")
-include("UnorderedIndices.jl")
-include("UnorderedDictionary.jl")
-include("indexing.jl")
-include("foreach.jl")
-include("map.jl")
-include("broadcast.jl")
-include("filter.jl")
-include("find.jl")
-include("reverse.jl")
-include("show.jl")
+@testset "Dictionaries" begin
+    include("Indices.jl")
+    include("Dictionary.jl")
+    include("ArrayIndices.jl")
+    include("ArrayDictionary.jl")
+    include("PairDictionary.jl")
+    include("FillDictionary.jl")
+    include("UnorderedIndices.jl")
+    include("UnorderedDictionary.jl")
+    include("indexing.jl")
+    include("foreach.jl")
+    include("map.jl")
+    include("broadcast.jl")
+    include("filter.jl")
+    include("find.jl")
+    include("reverse.jl")
+    include("show.jl")
+end
 
 # Run the following test without julia --check-bounds=yes mode
 cmd = deepcopy(Base.julia_cmd())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,11 @@ include("find.jl")
 include("reverse.jl")
 include("show.jl")
 
+# Simple mutable structure for `deepcopy` testing
+mutable struct Foo{T}
+    x::T
+end
+
 # Run the following test without julia --check-bounds=yes mode
 cmd = deepcopy(Base.julia_cmd())
 filter!(a->!startswith(a, "--check-bounds="), cmd.exec)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,11 @@ using Test
 using Dictionaries
 using Indexing
 
+# Simple mutable structure for `deepcopy` testing
+mutable struct Foo{T}
+    x::T
+end
+
 include("Indices.jl")
 include("Dictionary.jl")
 include("ArrayIndices.jl")
@@ -18,11 +23,6 @@ include("filter.jl")
 include("find.jl")
 include("reverse.jl")
 include("show.jl")
-
-# Simple mutable structure for `deepcopy` testing
-mutable struct Foo{T}
-    x::T
-end
 
 # Run the following test without julia --check-bounds=yes mode
 cmd = deepcopy(Base.julia_cmd())


### PR DESCRIPTION
When using `deepcopy` on `Dictionary` with non `isbits` indices, there will be a mismatch between the hashes (unchanged) and the new objects (different hash).
This PR should fix this by overloading `deepcopy_internal` as suggested in the `Base` docs.

I will just add some docs with an MWE where `master` would fail.