### PR TITLE
Add serialization/deserialization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,19 @@
-authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 name = "Dictionaries"
 uuid = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
-version = "0.3.23"
+authors = ["Andy Ferris <ferris.andy@gmail.com>"]
+version = "0.3.24"
 
 [deps]
 Indexing = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[compat]
+Indexing = "1.1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-
-[compat]
-julia = "1"
-Indexing = "1.1"

--- a/src/Dictionaries.jl
+++ b/src/Dictionaries.jl
@@ -3,6 +3,7 @@ module Dictionaries
 using Random
 using Indexing
 using Base: @propagate_inbounds, Callable
+using Serialization: Serialization, deserialize, serialize, serialize_type, AbstractSerializer, handle_deserialize, UNDEFREF_TAG
 
 export getindices, setindices!
 

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -188,6 +188,21 @@ function Base.deepcopy_internal(ind::Indices{T}, id::IdDict) where {T}
     return Indices{T}(Base.deepcopy_internal(ind.values, id))
 end
 
+function Serialization.serialize(s::AbstractSerializer, ind::T) where {T<:Indices}
+    serialize_type(s, T, false)
+    serialize(s, getfield(ind, :values))
+end
+
+function Serialization.deserialize(s::AbstractSerializer, T::Type{<:Indices})
+    tag = Int32(read(s.io, UInt8)::UInt8)
+    if tag != UNDEFREF_TAG
+        vals = handle_deserialize(s, tag)
+    else
+        error("could not deserialize $T")
+    end
+    return T(vals)
+end
+
 # private (note that newsize must be power of two)
 function rehash!(indices::Indices{I}, newsize::Int, values = (), include_last_values::Bool = true) where {I}
     slots = resize!(_slots(indices), newsize)

--- a/src/UnorderedIndices.jl
+++ b/src/UnorderedIndices.jl
@@ -77,6 +77,21 @@ function Base.deepcopy_internal(uinds::UnorderedIndices{T}, id::IdDict) where {T
     return UnorderedIndices{T}(Base.deepcopy_internal(collect(keys(uinds)), id))
 end
 
+function Serialization.serialize(s::AbstractSerializer, uinds::T) where {T<:UnorderedIndices}
+    serialize_type(s, T, false)
+    serialize(s, collect(keys(uinds)))
+end
+
+function Serialization.deserialize(s::AbstractSerializer, T::Type{<:UnorderedIndices})
+    tag = Int32(read(s.io, UInt8)::UInt8)
+    if tag != UNDEFREF_TAG
+        vals = handle_deserialize(s, tag)
+    else
+        error("could not deserialize $T")
+    end
+    return T(vals)
+end
+
 ## Length
 Base.length(h::UnorderedIndices) = h.count
 

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -146,8 +146,15 @@
     @test !isdictequal(Dictionary(['a','b'],[1,2]), Dictionary(['a','b','c'],[1,2,3]))
     @test !isdictequal(Dictionary(['a','b'],[1,2]), Dictionary(['b','a'],[2,3]))
 
-    dmutable = deepcopy(Dictionary([Foo(3), Foo(2)], rand(2)))
-    @test all(k -> haskey(dmutable, k), keys(dmutable))
+    dmut = Dictionary([Foo(3), Foo(2)], rand(2))
+    dmut_copy = deepcopy(dmut)
+    @test all(k -> haskey(dmut_copy, k), keys(dmut_copy))
+
+    mktemp() do path, io
+        serialize(path, dmut)
+        dmut_ser = deserialize(path)
+        @test all(k -> haskey(dmut_ser, k), keys(dmut_ser))
+    end
     
     d5 = Dictionary(['a','b'],[1,missing])
     @test isdictequal(d5, d5) === missing

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -151,8 +151,8 @@
     @test all(k -> haskey(dmut_copy, k), keys(dmut_copy))
 
     mktemp() do path, io
-        serialize(path, dmut)
-        dmut_ser = deserialize(path)
+        open(io->serialize(io, dmut), path, "w")
+        dmut_ser = deserialize(open(path, "r"))
         @test all(k -> haskey(dmut_ser, k), keys(dmut_ser))
     end
     

--- a/test/UnorderedDictionary.jl
+++ b/test/UnorderedDictionary.jl
@@ -116,8 +116,8 @@
     @test all(k -> haskey(dmut_copy, k), keys(dmut_copy))
 
     mktemp() do path, io
-        serialize(path, dmut)
-        dmut_ser = deserialize(path)
+        open(io->serialize(io, dmut), path, "w")
+        dmut_ser = deserialize(open(path, "r"))
         @test all(k -> haskey(dmut_ser, k), keys(dmut_ser))
     end
     

--- a/test/UnorderedDictionary.jl
+++ b/test/UnorderedDictionary.jl
@@ -111,8 +111,15 @@
     @test !isdictequal(UnorderedDictionary(['a','b'],[1,2]), UnorderedDictionary(['a','b','c'],[1,2,3]))
     @test !isdictequal(UnorderedDictionary(['a','b'],[1,2]), UnorderedDictionary(['b','a'],[2,3]))
 
-    dmutable = deepcopy(UnorderedDictionary([Foo(3), Foo(2)], rand(2)))
-    @test all(k -> haskey(dmutable, k), keys(dmutable))
+    dmut = UnorderedDictionary([Foo(3), Foo(2)], rand(2))
+    dmut_copy = deepcopy(dmut)
+    @test all(k -> haskey(dmut_copy, k), keys(dmut_copy))
+
+    mktemp() do path, io
+        serialize(path, dmut)
+        dmut_ser = deserialize(path)
+        @test all(k -> haskey(dmut_ser, k), keys(dmut_ser))
+    end
     
     d5 = UnorderedDictionary(['a','b'],[1,missing])
     @test isdictequal(d5, d5) === missing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using Dictionaries
 using Indexing
+using Serialization
 
 # Simple mutable structure for `deepcopy` testing
 mutable struct Foo{T}


### PR DESCRIPTION
Similar to #107, this allows serialization and deserialization to not copy the hashes and only the values.

This also adds some tests checking that no keys are left with the wrong hash when serializing.