### PR TITLE
Fix `deepcopy`/`serialize` when used after `delete!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dictionaries"
 uuid = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 authors = ["Andy Ferris <ferris.andy@gmail.com>"]
-version = "0.3.24"
+version = "0.3.25"
 
 [deps]
 Indexing = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"

--- a/src/Dictionary.jl
+++ b/src/Dictionary.jl
@@ -172,6 +172,14 @@ Base.convert(::Type{T}, dict::T) where {T<:Dictionary} = dict
 
 Base.copy(dict::Dictionary) = Dictionary(dict.indices, copy(dict.values))
 
+Base.deepcopy_internal(dict::Dictionary{I,T}, id::IdDict) where {I,T} = Dictionary{I,T}(Base.deepcopy_internal(keys(dict), id), Base.deepcopy_internal(collect(dict), id))
+
+function Serialization.serialize(s::AbstractSerializer, dict::T) where {T<:Dictionary}
+    serialize_type(s, T, false)
+    serialize(s, keys(dict))
+    serialize(s, collect(dict))
+end
+
 """
     dictionary(iter)
 

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -190,7 +190,7 @@ end
 
 function Serialization.serialize(s::AbstractSerializer, ind::T) where {T<:Indices}
     serialize_type(s, T, false)
-    serialize(s, getfield(ind, :values))
+    serialize(s, collect(ind))
 end
 
 function Serialization.deserialize(s::AbstractSerializer, T::Type{<:Indices})

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -185,7 +185,7 @@ function Base.copy(indices::ReverseIndices{I,Indices{I}}, ::Type{I2}) where {I, 
 end
 
 function Base.deepcopy_internal(ind::Indices{T}, id::IdDict) where {T}
-    return Indices{T}(Base.deepcopy_internal(ind.values, id))
+    return Indices{T}(Base.deepcopy_internal(collect(ind), id))
 end
 
 function Serialization.serialize(s::AbstractSerializer, ind::T) where {T<:Indices}

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -146,10 +146,11 @@
     @test !isdictequal(Dictionary(['a','b'],[1,2]), Dictionary(['a','b','c'],[1,2,3]))
     @test !isdictequal(Dictionary(['a','b'],[1,2]), Dictionary(['b','a'],[2,3]))
 
-    dmut = Dictionary(Foo.(1:10), rand(10))
+    foos = Foo.(1:10)
+    dmut = Dictionary(foos, rand(10))
     dmut_copy = deepcopy(dmut)
     @test all(k -> haskey(dmut_copy, k), keys(dmut_copy))
-    delete!(dmut, Foo(1))
+    delete!(dmut, foos[3])
     dmut_copy = deepcopy(dmut)
     @test all(k -> haskey(dmut_copy, k), keys(dmut_copy))
 

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -146,7 +146,10 @@
     @test !isdictequal(Dictionary(['a','b'],[1,2]), Dictionary(['a','b','c'],[1,2,3]))
     @test !isdictequal(Dictionary(['a','b'],[1,2]), Dictionary(['b','a'],[2,3]))
 
-    dmut = Dictionary([Foo(3), Foo(2)], rand(2))
+    dmut = Dictionary(Foo.(1:10), rand(10))
+    dmut_copy = deepcopy(dmut)
+    @test all(k -> haskey(dmut_copy, k), keys(dmut_copy))
+    delete!(dmut, Foo(1))
     dmut_copy = deepcopy(dmut)
     @test all(k -> haskey(dmut_copy, k), keys(dmut_copy))
 


### PR DESCRIPTION
Hey @andyferris !

It looks my `deepcopy` and `serialize` implementation have a bug.
I wrongly assumed that `indices.values == collect(indices)`.
It is visibly not true and create `undef` references when using non `isbits` structure.

I used `collect(indices)` instead and took care of updating the tests accordingly.

(version patch is bumped as well) 