### PR TITLE
Add `setwith!`

### DIFF
--- a/src/Dictionaries.jl
+++ b/src/Dictionaries.jl
@@ -10,7 +10,7 @@ export getindices, setindices!
 export AbstractDictionary, AbstractIndices, IndexError, ArrayIndices, Indices, Dictionary, ArrayDictionary, MappedDictionary, ReverseIndices, ReverseDictionary, DictionaryView, FilteredDictionary, FilteredIndices, BroadcastedDictionary, FillDictionary, UnorderedIndices, UnorderedDictionary
 
 export dictionary, index, distinct, disjoint, isdictequal, filterview, sortkeys, sortpairs, sortkeys!, sortpairs!
-export issettable, isinsertable, set!, unset!
+export issettable, isinsertable, set!, setwith!, unset!
 export istokenizable, tokentype, tokens, tokenized, gettoken, gettokenvalue, istokenassigned, settokenvalue!, gettoken!, deletetoken!, sharetokens
 
 include("AbstractDictionary.jl")

--- a/src/Dictionaries.jl
+++ b/src/Dictionaries.jl
@@ -47,7 +47,6 @@ end # module
 # * TODO: have `delete!` return next key, `deletetoken!` return next token.
 #   For these kinds of algorithms, probably need: firstindex, firsttoken, nextind, prevind,
 #   nexttoken, prevtoken, lastindex, lasttoken.
-# * A surface interface for updates like https://github.com/JuliaLang/julia/pull/31367
 # * More operations for "ordered" indices/sets (sort-based dictionaries and
 #   B-trees). We can probably formalize an interface around a trait here. Certain operations
 #   like slicing out an interval or performing a sort-merge co-iteration for `merge` become

--- a/src/insertion.jl
+++ b/src/insertion.jl
@@ -201,14 +201,14 @@ Update the value at `i` with the function `f` (`f(dict[i], value)`) or insert `v
 Hint: Use [`mergewith!`](@ref) to exclusively update an existing value, and `insert!` to exclusively
 insert a new value. See also `get!`.
 """
-function insertwith!(f, d::AbstractDictionary{I}, i, value) where {I}
+function setwith!(f, d::AbstractDictionary{I}, i, value) where {I}
     i2 = safe_convert(I, i)
     old_value = get(d, i2, nothing)
-    isnothing(old_val) ? insert!(d, i2, value) : d[i2] = f(old_value, value) 
-    return dict
+    isnothing(old_value) ? insert!(d, i2, value) : d[i2] = f(old_value, value) 
+    return d
 end
 
-insertwith!(f, ::AbstractIndices, i, value) = error("`insertwith!` does not work with `AbstractIndices`")
+setwith!(f, ::AbstractIndices, i, value) = error("`insertwith!` does not work with `AbstractIndices`")
 
 """
     set!(indices::AbstractIndices, i)

--- a/src/insertion.jl
+++ b/src/insertion.jl
@@ -30,6 +30,7 @@ function.
 """
 isinsertable(::AbstractIndices) = false
 
+safe_convert(::Type{I}, i::I) where {I} = i
 function safe_convert(::Type{I}, i) where {I}
     i2 = convert(I, i)
     if !isequal(i, i2)

--- a/src/insertion.jl
+++ b/src/insertion.jl
@@ -195,8 +195,7 @@ end
 
 Update the value at `i` with the function `f` (`f(dict[i], value)`) or insert `value`.
 
-Hint: Use [`mergewith!`](@ref) to exclusively update an existing value, and `insert!` to exclusively
-insert a new value. See also `get!`.
+Hint: Use [`mergewith!`](@ref) to merge `Dictionary`s together.
 """
 function setwith!(f, d::AbstractDictionary{I}, i, value) where {I}
     i2 = safe_convert(I, i)

--- a/src/insertion.jl
+++ b/src/insertion.jl
@@ -163,10 +163,7 @@ Hint: Use `setindex!` to exclusively update an existing value, and `insert!` to 
 insert a new value. See also `get!`.
 """
 @propagate_inbounds function set!(d::AbstractDictionary{I}, i, value) where {I}
-    i2 = convert(I, i)
-    if !isequal(i, i2)
-        throw(ArgumentError("$i is not a valid key for type $I"))
-    end
+    i2 = safe_convert(I, i)
     return set!(d, i2, value)
 end
 
@@ -237,10 +234,7 @@ set to `default`, which is returned.
 See also `get`, `set!`.
 """
 @propagate_inbounds function Base.get!(d::AbstractDictionary{I}, i, default) where {I}
-    i2 = convert(I, i)
-    if !isequal(i, i2)
-        throw(ArgumentError("$i is not a valid key for type $I"))
-    end
+    i2 = safe_convert(I, i)
     return get!(d, i2, default)
 end
 
@@ -265,10 +259,7 @@ Return the value `dict[i]` if index `i` exists. Otherwise, a new index `i` is in
 set to the value `f()`, which is returned.
 """
 function Base.get!(f::Callable, d::AbstractDictionary{I}, i) where {I}
-    i2 = convert(I, i)
-    if !isequal(i, i2)
-        throw(ArgumentError("$i is not a valid key for type $I"))
-    end
+    i2 = safe_convert(I, i)
     get!(f, d, i2)
 end
 
@@ -297,10 +288,7 @@ Delete the index `i` from `dict`. An error is thrown if `i` does not exist.
 See also `unset!`, `insert!`.
 """
 @propagate_inbounds function Base.delete!(d::AbstractDictionary{I}, i) where {I}
-    i2 = convert(I, i)
-    if !isequal(i, i2)
-        throw(ArgumentError("$i is not a valid key for type $I"))
-    end
+    i2 = safe_convert(I, i)
     return delete!(d, i2)
 end
 
@@ -326,10 +314,7 @@ Delete the index `i` from `dict` if it exists, or do nothing otherwise.
 See also `delete!`, `set!`.
 """
 @propagate_inbounds function unset!(indices::AbstractDictionary{I}, i) where {I}
-    i2 = convert(I, i)
-    if !isequal(i, i2)
-        throw(ArgumentError("$i is not a valid key for type $I"))
-    end
+    i2 = safe_convert(I, i)
     return unset!(indices, i2)
 end
 

--- a/src/insertion.jl
+++ b/src/insertion.jl
@@ -199,13 +199,13 @@ Update the value at `i` with the function `f` (`f(dict[i], value)`) or insert `v
 Hint: Use [`mergewith!`](@ref) to merge `Dictionary`s together.
 """
 function setwith!(f, d::AbstractDictionary{I}, i, value) where {I}
-    i2 = safe_convert(I, i)
-    old_value = get(d, i2, nothing)
-    isnothing(old_value) ? insert!(d, i2, value) : d[i2] = f(old_value, value) 
+    (had_token, token) = gettoken!(d, i)
+    new_value = had_token ? f(@inbounds(gettokenvalue(d, token)), value) : value
+    @inbounds settokenvalue!(d, token, new_value)
     return d
 end
 
-setwith!(f, ::AbstractIndices, i, value) = error("`insertwith!` does not work with `AbstractIndices`")
+setwith!(f, ::AbstractIndices, i, value) = error("`setwith!` does not work with `AbstractIndices`")
 
 """
     set!(indices::AbstractIndices, i)

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -42,10 +42,21 @@
     @test_throws IndexError insert!(d, 10, 12)
     @test d[10] == 11
     set!(d, 10, 12)
+    @test length(d) == 1setwith!(+, d, 10.0, 2.0)
     @test length(d) == 1
+    @test d[10] == 14
+    setwith!(+, d, 2.0, 2.0)
+    @test length(d) == 2
+    @test d[2] == 2
     @test d[10] == 12
-    d[10] = 13
+    setwith!(+, d, 10.0, 2.0)
     @test length(d) == 1
+    @test d[10] == 14
+    setwith!(+, d, 2.0, 2.0)
+    @test length(d) == 2
+    @test d[2] == 2
+    d[10] = 13
+    @test length(d) == 2
     @test d[10] == 13
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{10 = 13}"
     if VERSION < v"1.6-"

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -42,7 +42,7 @@
     @test_throws IndexError insert!(d, 10, 12)
     @test d[10] == 11
     set!(d, 10, 12)
-    @test length(d) == 1setwith!(+, d, 10.0, 2.0)
+    @test length(d) == setwith!(+, d, 10.0, 2.0)
     @test length(d) == 1
     @test d[10] == 14
     setwith!(+, d, 2.0, 2.0)

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -40,14 +40,9 @@
     @test !isempty(d)
     @test isequal(copy(d), d)
     @test_throws IndexError insert!(d, 10, 12)
-    @test d[10] == 11
-    set!(d, 10, 12)
-    @test length(d) == setwith!(+, d, 10.0, 2.0)
+    @test d[10.0] == 11
+    set!(d, 10.0, 12.0)
     @test length(d) == 1
-    @test d[10] == 14
-    setwith!(+, d, 2.0, 2.0)
-    @test length(d) == 2
-    @test d[2] == 2
     @test d[10] == 12
     setwith!(+, d, 10.0, 2.0)
     @test length(d) == 1
@@ -55,8 +50,9 @@
     setwith!(+, d, 2.0, 2.0)
     @test length(d) == 2
     @test d[2] == 2
-    d[10] = 13
-    @test length(d) == 2
+    delete!(d, 2)
+    @test length(d) == 1
+    d[10.0] = 13.0
     @test d[10] == 13
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{10 = 13}"
     if VERSION < v"1.6-"

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -94,8 +94,14 @@
     set!(d, 10.0, 12.0)
     @test length(d) == 1
     @test d[10] == 12
-    d[10.0] = 13.0
+    setwith!(+, d, 10.0, 2.0)
     @test length(d) == 1
+    @test d[10] == 14
+    setwith!(+, d, 2.0, 2.0)
+    @test length(d) == 2
+    @test d[2] == 2
+    d[10.0] = 13.0
+    @test length(d) == 2
     @test d[10] == 13
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{10 = 13}"
     if VERSION < v"1.6-"

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -100,8 +100,9 @@
     setwith!(+, d, 2.0, 2.0)
     @test length(d) == 2
     @test d[2] == 2
+    delete!(d, 2)
+    @test length(d) == 1
     d[10.0] = 13.0
-    @test length(d) == 2
     @test d[10] == 13
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{10 = 13}"
     if VERSION < v"1.6-"

--- a/test/Indices.jl
+++ b/test/Indices.jl
@@ -54,6 +54,7 @@
     @test length(set!(h, 2, 2)) == 2
     @test length(set!(h, 3.0, 3.0)) == 3
     @test_throws ErrorException set!(h, 4, 5)
+    @test_throws ErrorException setwith!(+, h, 3, 2)
 
     @testset "Comparison" begin
         i1 = Indices([1,2,3])

--- a/test/UnorderedDictionary.jl
+++ b/test/UnorderedDictionary.jl
@@ -78,8 +78,9 @@
     setwith!(+, d, 2.0, 2.0)
     @test length(d) == 2
     @test d[2] == 2
+    delete!(d, 2)
+    @test length(d) == 1
     d[10.0] = 13.0
-    @test length(d) == 2
     @test d[10] == 13
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{10 = 13}"
     if VERSION < v"1.6-"

--- a/test/UnorderedDictionary.jl
+++ b/test/UnorderedDictionary.jl
@@ -72,8 +72,14 @@
     set!(d, 10.0, 12.0)
     @test length(d) == 1
     @test d[10] == 12
-    d[10.0] = 13.0
+    setwith!(+, d, 10.0, 2.0)
     @test length(d) == 1
+    @test d[10] == 14
+    setwith!(+, d, 2.0, 2.0)
+    @test length(d) == 2
+    @test d[2] == 2
+    d[10.0] = 13.0
+    @test length(d) == 2
     @test d[10] == 13
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{10 = 13}"
     if VERSION < v"1.6-"


### PR DESCRIPTION
This PR proposes a new feature which is an equivalent of `mergewith!` with a `Dictionary` containing only one element.
This is much faster than building a `Dictionary` every time.
I did not use `token` as the `get` approach was faster.
Here are some benchmarks:
```
julia> using BenchmarkTools, Dictionaries
julia> function tokensetwith!(f, d::AbstractDictionary{I}, i, value) where {I}
    i2 = safe_convert(I, i)
    hastoken, token = gettoken!(d, i2)
    hastoken ? settokenvalue!(d, token, f(gettokenvalue(d, token), value)) : settokenvalue!(d, token, value) 
    return d
end
julia> @btime mergewith!(+, d, Dictionary(Ref(2), Ref(2.0))) setup=(d=Dictionary(1:5, rand(5)))
  131.679 ns (6 allocations: 448 bytes)
julia> @btime setwith!(+, d, 2, 2.0) setup=(d=Dictionary(1:5, rand(5)))
  7.993 ns (0 allocations: 0 bytes)
julia> @btime tokensetwith!(+, d, 2, 2.0) setup=(d=Dictionary(1:5, rand(5)))
  8.785 ns (0 allocations: 0 bytes)
```

Additionaly I started to use `safe_convert` instead of converting and equality checking to avoid code duplication,
