### PR TITLE
remove dependence on Julia internal `Core.Compiler.return_type`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Manifest.toml
+

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dictionaries"
 uuid = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 authors = ["Andy Ferris <ferris.andy@gmail.com>"]
-version = "0.3.25"
+version = "0.3.26"
 
 [deps]
 Indexing = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"

--- a/src/Dictionaries.jl
+++ b/src/Dictionaries.jl
@@ -14,14 +14,14 @@ export issettable, isinsertable, set!, unset!
 export istokenizable, tokentype, tokens, tokenized, gettoken, gettokenvalue, istokenassigned, settokenvalue!, gettoken!, deletetoken!, sharetokens
 
 """
-    return_type(f, types)::DataType
+    return_type(f, types)
 
 Find the return type of `f` called with `types`.
 
 !!! note 
     Currently, this method depends on `code_typed`.
 """
-function return_type(f, types)::DataType
+function return_type(f, types)
     return last(only(code_typed(f, types; 
                                 optimize=false, 
                                 debuginfo=:none)))

--- a/src/Dictionaries.jl
+++ b/src/Dictionaries.jl
@@ -13,6 +13,20 @@ export dictionary, index, distinct, disjoint, isdictequal, filterview, sortkeys,
 export issettable, isinsertable, set!, unset!
 export istokenizable, tokentype, tokens, tokenized, gettoken, gettokenvalue, istokenassigned, settokenvalue!, gettoken!, deletetoken!, sharetokens
 
+"""
+    return_type(f, types)::DataType
+
+Find the return type of `f` called with `types`.
+
+!!! note 
+    Currently, this method depends on `code_typed`.
+"""
+function return_type(f, types)::DataType
+    return last(only(code_typed(f, types; 
+                                optimize=false, 
+                                debuginfo=:none)))
+end
+
 include("AbstractDictionary.jl")
 include("AbstractIndices.jl")
 

--- a/src/Dictionary.jl
+++ b/src/Dictionary.jl
@@ -220,8 +220,8 @@ function _dictionary(key, value, ::Type{Dictionary}, iter)
     tmp = iterate(iter)
     if tmp === nothing
         IT = Base.@default_eltype(iter)
-        I = Core.Compiler.return_type(first, Tuple{IT})
-        T = Core.Compiler.return_type(last, Tuple{IT})
+        I = return_type(first, Tuple{IT})
+        T = return_type(last, Tuple{IT})
         return Dictionary{I, T}()
     end
     (x, s) = tmp

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -71,7 +71,7 @@ function Indices(iter)
     # is used. For an empty iterator, we actually don't know what the 
     # True(tm) eltype is, so the top of the type hierarchy (Any) is 
     # just as reasonable as the bottom (Union{})
-    I = isempty(iter) ? Any : eltype(iter)
+    I = typeof(iter) == Tuple{} ? Any : eltype(iter)
     
     return Indices{I}(iter)
 end

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -65,7 +65,15 @@ function Indices(iter)
         iter = collect(iter)
     end
 
-    return Indices{eltype(iter)}(iter)
+    # This is necessary to make map'ing across an empty dictionary work
+    # In both Julia 1.9 and 1.10 eltype(::Tuple{}) == Union{}
+    # but in Julia 1.10, this causes problems downstream when Indices{Union{}}
+    # is used. For an empty iterator, we actually don't know what the 
+    # True(tm) eltype is, so the top of the type hierarchy (Any) is 
+    # just as reasonable as the bottom (Union{})
+    I = isempty(iter) ? Any : eltype(iter)
+    
+    return Indices{I}(iter)
 end
 
 function Indices{I}(iter) where {I}

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -19,7 +19,7 @@ _data(d::BroadcastedDictionary) = getfield(d, :data)
     sharetokens = _sharetokens(dicts...)
     I = keytype(dicts[1])
     Ts = Base.Broadcast.eltypes(data)
-    T = Core.Compiler.return_type(f, Ts)
+    T = return_type(f, Ts)
 
     return BroadcastedDictionary{I, T, typeof(f), typeof(data)}(f, data, sharetokens)
 end

--- a/src/map.jl
+++ b/src/map.jl
@@ -88,13 +88,13 @@ function Base.map!(f, out::AbstractDictionary)
 end
 
 function Base.map(f, d::AbstractDictionary)
-    out = similar(d, Core.Compiler.return_type(f, Tuple{eltype(d)}))
+    out = similar(d, return_type(f, Tuple{eltype(d)}))
     @inbounds map!(f, out, d)
     return out
 end
 
 function Base.map(f, d::AbstractDictionary, ds::AbstractDictionary...)
-    out = similar(d, Core.Compiler.return_type(f, Tuple{eltype(d), map(eltype, ds)...}))
+    out = similar(d, return_type(f, Tuple{eltype(d), map(eltype, ds)...}))
     @inbounds map!(f, out, d, ds...)
     return out
 end
@@ -146,7 +146,7 @@ empty_type(::Type{<:MappedDictionary{<:Any, <:Any, <:Any, <:Tuple{D, Vararg{Abst
 if VERSION > v"1.6-"
     function Iterators.map(f, d::AbstractDictionary)
         I = keytype(d)
-        T = Core.Compiler.return_type(f, Tuple{eltype(d)}) # Base normally wouldn't invoke inference for something like this...
+        T = return_type(f, Tuple{eltype(d)}) # Base normally wouldn't invoke inference for something like this...
         return MappedDictionary{I, T, typeof(f), Tuple{typeof(d)}}(f, (d,))
     end
 end

--- a/test/map.jl
+++ b/test/map.jl
@@ -1,7 +1,7 @@
 @testset "map" begin
     function _mapview(f, d::AbstractDictionary)
         I = keytype(d)
-        T = Core.Compiler.return_type(f, Tuple{eltype(d)})
+        T = Dictionaries.return_type(f, Tuple{eltype(d)})
         
         return MappedDictionary{I, T, typeof(f), Tuple{typeof(d)}}(f, (d,))
     end


### PR DESCRIPTION
see also https://github.com/JuliaLang/julia/issues/52385

There's also another problem that arises on Julia 1.10 when `Indices` are constructed from an empty tuple, the resultant `Indices{Union{}}` create all sorts of problems. To get around this, I've added a check for empty tuples and changes the indices eltype to be `Any`. See also https://github.com/MakieOrg/AlgebraOfGraphics.jl/issues/472  