### PR TITLE
fix same-object copies in `deepcopy`

### DIFF
--- a/src/Dictionary.jl
+++ b/src/Dictionary.jl
@@ -172,8 +172,6 @@ Base.convert(::Type{T}, dict::T) where {T<:Dictionary} = dict
 
 Base.copy(dict::Dictionary) = Dictionary(dict.indices, copy(dict.values))
 
-Base.deepcopy_internal(dict::Dictionary{I,T}, id::IdDict) where {I,T} = Dictionary{I,T}(Base.deepcopy_internal(keys(dict), id), Base.deepcopy_internal(collect(dict), id))
-
 function Serialization.serialize(s::AbstractSerializer, dict::T) where {T<:Dictionary}
     serialize_type(s, T, false)
     serialize(s, keys(dict))

--- a/src/Indices.jl
+++ b/src/Indices.jl
@@ -185,7 +185,11 @@ function Base.copy(indices::ReverseIndices{I,Indices{I}}, ::Type{I2}) where {I, 
 end
 
 function Base.deepcopy_internal(ind::Indices{T}, id::IdDict) where {T}
-    return Indices{T}(Base.deepcopy_internal(collect(ind), id))
+    if haskey(id, ind)
+        id[ind]::Indices{T}
+    else
+        id[ind] = Indices{T}(Base.deepcopy_internal(collect(ind), id))
+    end
 end
 
 function Serialization.serialize(s::AbstractSerializer, ind::T) where {T<:Indices}

--- a/src/UnorderedIndices.jl
+++ b/src/UnorderedIndices.jl
@@ -74,7 +74,11 @@ function Base.copy(h::UnorderedIndices{T}, ::Type{T}) where {T}
 end
 
 function Base.deepcopy_internal(uinds::UnorderedIndices{T}, id::IdDict) where {T}
-    return UnorderedIndices{T}(Base.deepcopy_internal(collect(keys(uinds)), id))
+    if haskey(id, uinds)
+        id[uinds]::UnorderedIndices{T}
+    else
+        id[uinds] = UnorderedIndices{T}(Base.deepcopy_internal(collect(keys(uinds)), id))
+    end
 end
 
 function Serialization.serialize(s::AbstractSerializer, uinds::T) where {T<:UnorderedIndices}

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -153,6 +153,8 @@
     delete!(dmut, foos[3])
     dmut_copy = deepcopy(dmut)
     @test all(k -> haskey(dmut_copy, k), keys(dmut_copy))
+    dmut2_copy = deepcopy((dmut, dmut));
+    @test dmut2_copy[1] === dmut2_copy[2];
 
     mktemp() do path, io
         open(io->serialize(io, dmut), path, "w")

--- a/test/UnorderedDictionary.jl
+++ b/test/UnorderedDictionary.jl
@@ -114,6 +114,8 @@
     dmut = UnorderedDictionary([Foo(3), Foo(2)], rand(2))
     dmut_copy = deepcopy(dmut)
     @test all(k -> haskey(dmut_copy, k), keys(dmut_copy))
+    dmut2_copy = deepcopy((dmut, dmut));
+    @test dmut2_copy[1] === dmut2_copy[2];
 
     mktemp() do path, io
         open(io->serialize(io, dmut), path, "w")

--- a/test/UnorderedIndices.jl
+++ b/test/UnorderedIndices.jl
@@ -12,6 +12,8 @@
     @test h == copy(h)
     @test isempty(h)
     @test issetequal(copy(h), h)
+    h2 = deepcopy((h, h))
+    @test h2[1] === h2[2];
     @test_throws IndexError h[10]
     @test length(unset!(h, 10)) == 0
     io = IOBuffer(); print(io, h); @test String(take!(io)) == "{}"


### PR DESCRIPTION
Previously same-object references were not copied correctly and the following would fail.
```
x = Indices()
y = deepcopy((x, x))
@test y[1] === y[2]
```
In order to not copy the same object multiple times in `deepcopy`, an `IdDict` is passed to `deepcopy_internal` which should be used by implementations.
This commit makes use of that dictionary to store already copied objects and fix the above issue.

Also `deepcopy_internal` on `Dictionary` was superfluous and was removed along the way.