### PR TITLE
Fix `deepcopy` when used after `delete!`

### DIFF
--- a/src/Dictionary.jl
+++ b/src/Dictionary.jl
@@ -172,6 +172,14 @@ Base.convert(::Type{T}, dict::T) where {T<:Dictionary} = dict
 
 Base.copy(dict::Dictionary) = Dictionary(dict.indices, copy(dict.values))
 
+function Base.deepcopy_internal(dict::Dictionary{I,T}, id::IdDict) where {I,T}
+    if haskey(id, dict)
+        id[dict]::Dictionary{I,T}
+    else
+        id[dict] = Dictionary{I,T}(Base.deepcopy_internal(keys(dict), id), Base.deepcopy_internal(collect(dict), id))
+    end
+end
+
 function Serialization.serialize(s::AbstractSerializer, dict::T) where {T<:Dictionary}
     serialize_type(s, T, false)
     serialize(s, keys(dict))

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -402,4 +402,10 @@
             @test mergewith(+, d3, d1, d2) isa Dictionary{Int, Float64}
         end
     end
+
+    @testset "deepcopy" begin
+        local d = Dictionary(1:4, 1:4)
+        delete!(d, 2)
+        @test d == deepcopy(d)
+    end
 end


### PR DESCRIPTION
Fixes #133 

The bug fixed in #112 was reintroduced in #131 when one of the `deepcopy_internal` methods was deleted.

I have added a basic test for this issue, but I think `deepcopy` needs more testing.

CC: @stev47 @andyferris @theogf 