### PR TITLE
Stop using `Core.Compiler.return_type`

### DIFF
--- a/src/Dictionary.jl
+++ b/src/Dictionary.jl
@@ -226,8 +226,8 @@ function _dictionary(key, value, ::Type{Dictionary}, iter)
     tmp = iterate(iter)
     if tmp === nothing
         IT = Base.@default_eltype(iter)
-        I = IT == Union{} ? Union{} : Core.Compiler.return_type(first, Tuple{IT})
-        T = IT == Union{} ? Union{} : Core.Compiler.return_type(last, Tuple{IT})
+        I = Base.promote_op(first, IT)
+        T = Base.promote_op(last, IT)
         return Dictionary{I, T}()
     end
     (x, s) = tmp

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -19,7 +19,7 @@ _data(d::BroadcastedDictionary) = getfield(d, :data)
     sharetokens = _sharetokens(dicts...)
     I = keytype(dicts[1])
     Ts = Base.Broadcast.eltypes(data)
-    T = Core.Compiler.return_type(f, Ts)
+    T = Base.promote_op(f, Ts)
 
     return BroadcastedDictionary{I, T, typeof(f), typeof(data)}(f, data, sharetokens)
 end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -19,7 +19,7 @@ _data(d::BroadcastedDictionary) = getfield(d, :data)
     sharetokens = _sharetokens(dicts...)
     I = keytype(dicts[1])
     Ts = Base.Broadcast.eltypes(data)
-    T = Base.promote_op(f, Ts)
+    T = Base.promote_op(f, Ts...)
 
     return BroadcastedDictionary{I, T, typeof(f), typeof(data)}(f, data, sharetokens)
 end

--- a/src/map.jl
+++ b/src/map.jl
@@ -88,13 +88,13 @@ function Base.map!(f, out::AbstractDictionary)
 end
 
 function Base.map(f, d::AbstractDictionary)
-    out = similar(d, Core.Compiler.return_type(f, Tuple{eltype(d)}))
+    out = similar(d, Base.promote_op(f, eltype(d)))
     @inbounds map!(f, out, d)
     return out
 end
 
 function Base.map(f, d::AbstractDictionary, ds::AbstractDictionary...)
-    out = similar(d, Core.Compiler.return_type(f, Tuple{eltype(d), map(eltype, ds)...}))
+    out = similar(d, Base.promote_op(f, eltype(d), map(eltype, ds)...))
     @inbounds map!(f, out, d, ds...)
     return out
 end
@@ -145,6 +145,6 @@ empty_type(::Type{<:MappedDictionary{<:Any, <:Any, <:Any, <:Tuple{D, Vararg{Abst
 
 function Iterators.map(f, d::AbstractDictionary)
     I = keytype(d)
-    T = Core.Compiler.return_type(f, Tuple{eltype(d)}) # Base normally wouldn't invoke inference for something like this...
+    T = Base.promote_op(f, eltype(d)) # Base normally wouldn't invoke inference for something like this...
     return MappedDictionary{I, T, typeof(f), Tuple{typeof(d)}}(f, (d,))
 end

--- a/test/map.jl
+++ b/test/map.jl
@@ -1,7 +1,7 @@
 @testset "map" begin
     function _mapview(f, d::AbstractDictionary)
         I = keytype(d)
-        T = Base.promote_op(f, Tuple{eltype(d)})
+        T = Base.promote_op(f, eltype(d))
         
         return MappedDictionary{I, T, typeof(f), Tuple{typeof(d)}}(f, (d,))
     end

--- a/test/map.jl
+++ b/test/map.jl
@@ -1,7 +1,7 @@
 @testset "map" begin
     function _mapview(f, d::AbstractDictionary)
         I = keytype(d)
-        T = Core.Compiler.return_type(f, Tuple{eltype(d)})
+        T = Base.promote_op(f, Tuple{eltype(d)})
         
         return MappedDictionary{I, T, typeof(f), Tuple{typeof(d)}}(f, (d,))
     end


### PR DESCRIPTION
`Base.promte_op` is a strictly less sketchy version.