### PR TITLE
make AbstractDictionary a subtype of AbstractDict

### DIFF
--- a/src/AbstractDictionary.jl
+++ b/src/AbstractDictionary.jl
@@ -20,7 +20,7 @@ If arbitrary indices can be added to or removed from the dictionary, implement:
  * `insert!(dict::AbstractDictionary{I, T}, ::I, ::T}` (returning `dict`)
  * `delete!(dict::AbstractDictionary{I, T}, ::I}` (returning `dict`)
 """
-abstract type AbstractDictionary{I, T}; end
+abstract type AbstractDictionary{I, T} <: AbstractDict{I, T}; end
 abstract type AbstractIndices{I} <: AbstractDictionary{I, I}; end
 
 Base.eltype(d::AbstractDictionary) = eltype(typeof(d))


### PR DESCRIPTION
Would this be a problem? This would make it easier to use Dictionary if an AbstractDict is already supported by a library