### PR TITLE
Use _truncate_at_width_or_chars to avoid ANSI truncation

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -1,6 +1,6 @@
 # Simple "print"-like rendering, use "{ ... }" brackets for compactness
 function Base.show(io::IO, inds::AbstractIndices)
-    limit = get(io, :limit, false) ? Int64(10) : typemax(Int64)
+    limit = get(io, :limit, false) ? Int(10) : typemax(Int)
     comma = false
     print(io, "{")
     for i in inds
@@ -19,7 +19,7 @@ function Base.show(io::IO, inds::AbstractIndices)
 end
 
 function Base.show(io::IO, d::AbstractDictionary)
-    limit = get(io, :limit, false) ? Int64(10) : typemax(Int64)
+    limit = get(io, :limit, false) ? Int(10) : typemax(Int)
     comma = false
     print(io, "{")
     for i in keys(d)
@@ -52,16 +52,16 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractIndices)
 
     # Designed to be efficient for very large sets of unknown lengths
 
-    n_lines = max(Int64(3), get(io, :limit, false) ? Int64(displaysize(io)[1] - 4) : typemax(Int64))
-    n_cols = max(Int64(2), get(io, :limit, false) ? Int64(displaysize(io)[2] - 1) : typemax(Int64))
-    n_lines_top = n_lines ÷ Int64(2)
+    n_lines = max(Int(3), get(io, :limit, false) ? Int(displaysize(io)[1] - 4) : typemax(Int))
+    n_cols = max(Int(2), get(io, :limit, false) ? Int(displaysize(io)[2] - 1) : typemax(Int))
+    n_lines_top = n_lines ÷ Int(2)
     n_lines_bottom = n_lines - n_lines_top
 
     # First we collect strings of all the relevant elements
     top_ind_strs = Vector{String}()
     bottom_ind_strs = Vector{String}()
 
-    top_lines = Int64(1)
+    top_lines = Int(1)
     top_full = false
     top_last_index = Base.RefValue{keytype(d)}()
     for i in keys(d)
@@ -74,7 +74,7 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractIndices)
         end
     end
 
-    bottom_lines = Int64(1)
+    bottom_lines = Int(1)
     bottom_full = false
     if top_full
         for i in Iterators.reverse(keys(d))
@@ -135,9 +135,9 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractDictionary)
 
     # Designed to be efficient for very large sets of unknown lengths
 
-    n_lines = max(Int64(3), get(io, :limit, false) ? Int64(displaysize(io)[1] - 4) : typemax(Int64))
-    n_cols = max(Int64(8), get(io, :limit, false) ? Int64(displaysize(io)[2] - 4) : typemax(Int64))
-    n_lines_top = n_lines ÷ Int64(2)
+    n_lines = max(Int(3), get(io, :limit, false) ? Int(displaysize(io)[1] - 4) : typemax(Int))
+    n_cols = max(Int(8), get(io, :limit, false) ? Int(displaysize(io)[2] - 4) : typemax(Int))
+    n_lines_top = n_lines ÷ Int(2)
     n_lines_bottom = n_lines - n_lines_top
 
     # First we collect strings of all the relevant elements
@@ -146,7 +146,7 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractDictionary)
     bottom_val_strs = Vector{String}()
     bottom_ind_strs = Vector{String}()
 
-    top_lines = Int64(1)
+    top_lines = Int(1)
     top_full = false
     top_last_index = Base.RefValue{keytype(d)}()
     for i in keys(d)
@@ -164,7 +164,7 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractDictionary)
         end
     end
 
-    bottom_lines = Int64(1)
+    bottom_lines = Int(1)
     bottom_full = false
     if top_full
         for i in Iterators.reverse(keys(d))

--- a/src/show.jl
+++ b/src/show.jl
@@ -246,24 +246,7 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractDictionary)
 end
 
 function shrink_to!(strs, width)
-    for i in keys(strs)
-        str = strs[i]
-        if textwidth(str) > width
-            new_str = ""
-            w = 0
-            for c in str
-                new_w = textwidth(c)
-                if new_w + w < width
-                    new_str = new_str * c
-                    w += new_w
-                else
-                    new_str = new_str * "…"
-                    break
-                end
-            end
-            strs[i] = new_str
-        end
-    end
+    strs .= Base._truncate_at_width_or_chars(true, strs, width)
 end
 
 # TODO fix `repr`

--- a/src/show.jl
+++ b/src/show.jl
@@ -246,7 +246,7 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractDictionary)
 end
 
 function shrink_to!(strs, width)
-    strs .= Base._truncate_at_width_or_chars(true, strs, width)
+    strs .= Base._truncate_at_width_or_chars.(true, strs, width)
 end
 
 # TODO fix `repr`

--- a/src/show.jl
+++ b/src/show.jl
@@ -246,7 +246,11 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractDictionary)
 end
 
 function shrink_to!(strs, width)
-    strs .= Base._truncate_at_width_or_chars.(true, strs, width)
+    @static if VERSION >= v"1.9"
+      strs .= Base._truncate_at_width_or_chars.(true, strs, width)
+    else
+      strs .= Base._truncate_at_width_or_chars.(strs, width)
+    end
 end
 
 # TODO fix `repr`


### PR DESCRIPTION
The manual truncation of strings lead to the following problem:

```julia
using Random, Dictionaries
struct Foo end
Base.show(io::IO, ::Foo) = printstyled(io, "abc"^100; color = rand((:blue, :green, :red)))
Dictionary([randstring(5) for _ in 1:10], fill(Foo(), 10))
```

On `main` we get:

![image](https://github.com/andyferris/Dictionaries.jl/assets/11480067/f41debd6-9cea-4055-9ad3-9a6c4722ffa9)

The issue is that the ANSI characters are truncated and the color bleeds to the next input.

Using the same function that `Base` use for `show` solve the issue:

![image](https://github.com/andyferris/Dictionaries.jl/assets/11480067/6550a67e-315b-4f8b-afb9-04c7742b0160)

I am not super sure how to test this though.