### PR TITLE
Slight `show` and `summary` improvements

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -106,12 +106,12 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractIndices)
 
     if Base.IteratorSize(d) === Base.SizeUnknown()
         if bottom_full
-            print(io, "Greater than $(length(ind_strs))-element $(typeof(d))")
+            print(io, "Greater than $(length(ind_strs))-element $(typeof(d)):")
         else
-            print(io, "$(length(ind_strs))-element $(typeof(d))")
+            print(io, "$(length(ind_strs))-element $(typeof(d)):")
         end
     else
-        print(io, "$(length(d))-element $(typeof(d))")
+        print(io, "$(length(d))-element $(typeof(d)):")
     end
 
     # Now find padding sizes
@@ -205,12 +205,12 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractDictionary)
 
     if Base.IteratorSize(d) === Base.SizeUnknown()
         if bottom_full
-            print(io, "Greater than $(length(ind_strs))-element $(typeof(d))")
+            print(io, "Greater than $(length(ind_strs))-element $(typeof(d)):")
         else
-            print(io, "$(length(ind_strs))-element $(typeof(d))")
+            print(io, "$(length(ind_strs))-element $(typeof(d)):")
         end
     else
-        print(io, "$(length(d))-element $(typeof(d))")
+        print(io, "$(length(d))-element $(typeof(d)):")
     end
 
     # Now find padding sizes

--- a/src/show.jl
+++ b/src/show.jl
@@ -111,7 +111,8 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractIndices)
             print(io, "$(length(ind_strs))-element $(typeof(d)):")
         end
     else
-        print(io, "$(length(d))-element $(typeof(d)):")
+        summary(io, d)
+        print(io, ":")
     end
 
     # Now find padding sizes
@@ -210,7 +211,8 @@ function Base.show(io::IO, ::MIME"text/plain", d::AbstractDictionary)
             print(io, "$(length(ind_strs))-element $(typeof(d)):")
         end
     else
-        print(io, "$(length(d))-element $(typeof(d)):")
+        summary(io, d)
+        print(io, ":")
     end
 
     # Now find padding sizes

--- a/src/show.jl
+++ b/src/show.jl
@@ -253,4 +253,14 @@ function shrink_to!(strs, width)
     end
 end
 
+Base.summary(io::IO, dict::AbstractDictionary) = dict_summary(io, dict)
+
+function dict_summary(io::IO, dict)
+    if Base.IteratorSize(dict) === Base.SizeUnknown()
+        print(io, typeof(dict))
+    else
+        print(io, length(d), "-element ", typeof(dict))
+    end
+end
+
 # TODO fix `repr`

--- a/src/show.jl
+++ b/src/show.jl
@@ -261,7 +261,7 @@ function dict_summary(io::IO, dict)
     if Base.IteratorSize(dict) === Base.SizeUnknown()
         print(io, typeof(dict))
     else
-        print(io, length(d), "-element ", typeof(dict))
+        print(io, length(dict), "-element ", typeof(dict))
     end
 end
 

--- a/test/ArrayDictionary.jl
+++ b/test/ArrayDictionary.jl
@@ -51,7 +51,7 @@
     d[10.0] = 13.0
     @test d[10] == 13
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{10 = 13}"
-    io = IOBuffer(); show(io, MIME"text/plain"(), d); @test String(take!(io)) == "1-element ArrayDictionary{Int64, Int64, ArrayIndices{Int64, Vector{Int64}}, Vector{Int64}}\n 10 │ 13"
+    io = IOBuffer(); show(io, MIME"text/plain"(), d); @test String(take!(io)) == "1-element ArrayDictionary{Int64, Int64, ArrayIndices{Int64, Vector{Int64}}, Vector{Int64}}:\n 10 │ 13"
     @test !isequal(d, empty(d))
     @test isequal(d, copy(d))
     @test isempty(empty(d))
@@ -84,7 +84,7 @@
         dictcopy = copy(dict)
         @test dict isa ArrayDictionary{Int64, String}
         @test !sharetokens(dict, dictcopy)
-        io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element ArrayDictionary{Int64, String, ArrayIndices{Int64, Vector{Int64}}, Vector{String}}\n 1 │ #undef\n 2 │ #undef"
+        io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element ArrayDictionary{Int64, String, ArrayIndices{Int64, Vector{Int64}}, Vector{String}}:\n 1 │ #undef\n 2 │ #undef"
         @test all(!isassigned(dict, i) for i in collect(keys(dict)))
         @test all(!isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
         @test sharetokens(dict, ArrayDictionary{Int64, String}(dict))

--- a/test/ArrayIndices.jl
+++ b/test/ArrayIndices.jl
@@ -26,7 +26,7 @@
     @test length(set!(inds, 10)) == 1
     @test_throws IndexError insert!(inds, 10)
     io = IOBuffer(); print(io, inds); @test String(take!(io)) == "{10}"
-    io = IOBuffer(); show(io, MIME"text/plain"(), inds); @test String(take!(io)) == "1-element ArrayIndices{Int64, Vector{Int64}}\n 10"
+    io = IOBuffer(); show(io, MIME"text/plain"(), inds); @test String(take!(io)) == "1-element ArrayIndices{Int64, Vector{Int64}}:\n 10"
     @test !isequal(inds, empty(inds))
     @test isequal(inds, copy(inds))
     @test isempty(empty(inds))

--- a/test/Dictionary.jl
+++ b/test/Dictionary.jl
@@ -101,7 +101,7 @@
     d[10.0] = 13.0
     @test d[10] == 13
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{10 = 13}"
-    io = IOBuffer(); show(io, MIME"text/plain"(), d); @test String(take!(io)) == "1-element Dictionary{Int64, Int64}\n 10 │ 13"
+    io = IOBuffer(); show(io, MIME"text/plain"(), d); @test String(take!(io)) == "1-element Dictionary{Int64, Int64}:\n 10 │ 13"
     @test !isequal(d, empty(d))
     @test isequal(d, copy(d))
     @test isempty(empty(d))
@@ -197,7 +197,7 @@
     dictcopy = copy(dict)
     @test dict isa Dictionary{Int64, String}
     @test !sharetokens(dict, dictcopy)
-    io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element Dictionary{Int64, String}\n 1 │ #undef\n 2 │ #undef"
+    io = IOBuffer(); show(io, MIME"text/plain"(), dict); @test String(take!(io)) == "2-element Dictionary{Int64, String}:\n 1 │ #undef\n 2 │ #undef"
     @test all(!isassigned(dict, i) for i in collect(keys(dict)))
     @test all(!isassigned(dictcopy, i) for i in collect(keys(dictcopy)))
     @test sharetokens(dict, Dictionary{Int64, String}(dict))

--- a/test/Indices.jl
+++ b/test/Indices.jl
@@ -33,7 +33,7 @@
     @test length(set!(h, 10)) == 1
     @test_throws IndexError insert!(h, 10)
     io = IOBuffer(); print(io, h); @test String(take!(io)) == "{10}"
-    io = IOBuffer(); show(io, MIME"text/plain"(), h); @test String(take!(io)) == "1-element Indices{Int64}\n 10"
+    io = IOBuffer(); show(io, MIME"text/plain"(), h); @test String(take!(io)) == "1-element Indices{Int64}:\n 10"
     @test !isequal(h, empty(h))
     @test isequal(h, copy(h))
     @test isempty(empty(h))

--- a/test/UnorderedDictionary.jl
+++ b/test/UnorderedDictionary.jl
@@ -79,7 +79,7 @@
     d[10.0] = 13.0
     @test d[10] == 13
     io = IOBuffer(); print(io, d); @test String(take!(io)) == "{10 = 13}"
-    io = IOBuffer(); show(io, MIME"text/plain"(), d); @test String(take!(io)) == "1-element UnorderedDictionary{Int64, Int64}\n 10 │ 13"
+    io = IOBuffer(); show(io, MIME"text/plain"(), d); @test String(take!(io)) == "1-element UnorderedDictionary{Int64, Int64}:\n 10 │ 13"
     @test !isdictequal(d, empty(d))
     @test isdictequal(d, copy(d))
     @test isempty(empty(d))
@@ -144,8 +144,8 @@
     @test dict isa UnorderedDictionary{Int64, String}
     @test !sharetokens(dict, dictcopy)
     io = IOBuffer(); show(io, MIME"text/plain"(), dict); str = String(take!(io)); @test(
-        str == "2-element UnorderedDictionary{Int64, String}\n 1 │ #undef\n 2 │ #undef" ||
-        str == "2-element UnorderedDictionary{Int64, String}\n 2 │ #undef\n 1 │ #undef"
+        str == "2-element UnorderedDictionary{Int64, String}:\n 1 │ #undef\n 2 │ #undef" ||
+        str == "2-element UnorderedDictionary{Int64, String}:\n 2 │ #undef\n 1 │ #undef"
     )
     @test all(!isassigned(dict, i) for i in collect(keys(dict)))
     @test all(!isassigned(dictcopy, i) for i in collect(keys(dictcopy)))

--- a/test/UnorderedIndices.jl
+++ b/test/UnorderedIndices.jl
@@ -34,7 +34,7 @@
     @test length(set!(h, 10)) == 1
     @test_throws IndexError insert!(h, 10)
     io = IOBuffer(); print(io, h); @test String(take!(io)) == "{10}"
-    io = IOBuffer(); show(io, MIME"text/plain"(), h); @test String(take!(io)) == "1-element UnorderedIndices{Int64}\n 10"
+    io = IOBuffer(); show(io, MIME"text/plain"(), h); @test String(take!(io)) == "1-element UnorderedIndices{Int64}:\n 10"
     @test !isequal(h, empty(h))
     @test issetequal(h, copy(h))
     @test isempty(empty(h))

--- a/test/show.jl
+++ b/test/show.jl
@@ -7,25 +7,25 @@
     end
 
     @test show_str(Indices{Int64}()) == "0-element Indices{Int64}"
-    @test show_str(Indices{Int64}(1:3)) == "3-element Indices{Int64}\n 1\n 2\n 3"
-    @test show_str(Indices{Int64}(1:100)) == "100-element Indices{Int64}\n 1\n 2\n 3\n ⋮\n 99\n 100"
-    @test show_str(filterview(iseven, Indices{Int64}(1:100))) == "Greater than 6-element FilteredIndices{Int64, Indices{Int64}, typeof(iseven)}\n 2\n 4\n 6\n ⋮\n 98\n 100"
+    @test show_str(Indices{Int64}(1:3)) == "3-element Indices{Int64}:\n 1\n 2\n 3"
+    @test show_str(Indices{Int64}(1:100)) == "100-element Indices{Int64}:\n 1\n 2\n 3\n ⋮\n 99\n 100"
+    @test show_str(filterview(iseven, Indices{Int64}(1:100))) == "Greater than 6-element FilteredIndices{Int64, Indices{Int64}, typeof(iseven)}:\n 2\n 4\n 6\n ⋮\n 98\n 100"
     if Int === Int64
-        @test show_str(Indices{Vector{Int64}}([collect(1:100)])) == "1-element Indices{Vector{Int64}}\n [1, 2, 3, 4, 5, 6,…"
-        @test show_str(Indices{Vector{Int64}}([collect(1:(100+i)) for i in 1:100])) == "100-element Indices{Vector{Int64}}\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…\n ⋮\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…"
+        @test show_str(Indices{Vector{Int64}}([collect(1:100)])) == "1-element Indices{Vector{Int64}}:\n [1, 2, 3, 4, 5, 6,…"
+        @test show_str(Indices{Vector{Int64}}([collect(1:(100+i)) for i in 1:100])) == "100-element Indices{Vector{Int64}}:\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…\n ⋮\n [1, 2, 3, 4, 5, 6,…\n [1, 2, 3, 4, 5, 6,…"
     else
-        @test show_str(Indices{Vector{Int64}}([collect(1:100)])) == "1-element Indices{Vector{Int64}}\n Int64[1, 2, 3, 4, …"
-        @test show_str(Indices{Vector{Int64}}([collect(1:(100+i)) for i in 1:100])) == "100-element Indices{Vector{Int64}}\n Int64[1, 2, 3, 4, …\n Int64[1, 2, 3, 4, …\n Int64[1, 2, 3, 4, …\n ⋮\n Int64[1, 2, 3, 4, …\n Int64[1, 2, 3, 4, …"
+        @test show_str(Indices{Vector{Int64}}([collect(1:100)])) == "1-element Indices{Vector{Int64}}:\n Int64[1, 2, 3, 4, …"
+        @test show_str(Indices{Vector{Int64}}([collect(1:(100+i)) for i in 1:100])) == "100-element Indices{Vector{Int64}}:\n Int64[1, 2, 3, 4, …\n Int64[1, 2, 3, 4, …\n Int64[1, 2, 3, 4, …\n ⋮\n Int64[1, 2, 3, 4, …\n Int64[1, 2, 3, 4, …"
     end
 
     @test show_str(Dictionary{Int64,Int64}()) == "0-element Dictionary{Int64, Int64}"
-    @test show_str(Dictionary{Int64,Int64}(1:3,101:103)) == "3-element Dictionary{Int64, Int64}\n 1 │ 101\n 2 │ 102\n 3 │ 103"
-    @test show_str(Dictionary{Int64,Int64}(1:100,101:200)) == "100-element Dictionary{Int64, Int64}\n   1 │ 101\n   2 │ 102\n   3 │ 103\n   ⋮ │ ⋮\n  99 │ 199\n 100 │ 200"
-    @test show_str(filterview(iseven, Dictionary{Int64,Int64}(1:100,101:200))) == "Greater than 6-element FilteredDictionary{Int64, Int64, Dictionary{Int64, Int64}, typeof(iseven)}\n   2 │ 102\n   4 │ 104\n   6 │ 106\n   ⋮ │ ⋮\n  98 │ 198\n 100 │ 200"
-    @test show_str(Dictionary{Int64,Int64}(collect(1:100), collect(101:200))) == "100-element Dictionary{Int64, Int64}\n   1 │ 101\n   2 │ 102\n   3 │ 103\n   ⋮ │ ⋮\n  99 │ 199\n 100 │ 200"
+    @test show_str(Dictionary{Int64,Int64}(1:3,101:103)) == "3-element Dictionary{Int64, Int64}:\n 1 │ 101\n 2 │ 102\n 3 │ 103"
+    @test show_str(Dictionary{Int64,Int64}(1:100,101:200)) == "100-element Dictionary{Int64, Int64}:\n   1 │ 101\n   2 │ 102\n   3 │ 103\n   ⋮ │ ⋮\n  99 │ 199\n 100 │ 200"
+    @test show_str(filterview(iseven, Dictionary{Int64,Int64}(1:100,101:200))) == "Greater than 6-element FilteredDictionary{Int64, Int64, Dictionary{Int64, Int64}, typeof(iseven)}:\n   2 │ 102\n   4 │ 104\n   6 │ 106\n   ⋮ │ ⋮\n  98 │ 198\n 100 │ 200"
+    @test show_str(Dictionary{Int64,Int64}(collect(1:100), collect(101:200))) == "100-element Dictionary{Int64, Int64}:\n   1 │ 101\n   2 │ 102\n   3 │ 103\n   ⋮ │ ⋮\n  99 │ 199\n 100 │ 200"
     if Int === Int64
-        @test show_str(Dictionary{Vector{Int64},Vector{Int64}}([collect(1:100+i) for i in 1:100],[collect(101:200+i) for i in 1:100])) == "100-element Dictionary{Vector{Int64}, Vector{Int64}}\n [1, 2, … │ [101, 1…\n [1, 2, … │ [101, 1…\n [1, 2, … │ [101, 1…\n        ⋮ │ ⋮\n [1, 2, … │ [101, 1…\n [1, 2, … │ [101, 1…"
+        @test show_str(Dictionary{Vector{Int64},Vector{Int64}}([collect(1:100+i) for i in 1:100],[collect(101:200+i) for i in 1:100])) == "100-element Dictionary{Vector{Int64}, Vector{Int64}}:\n [1, 2, … │ [101, 1…\n [1, 2, … │ [101, 1…\n [1, 2, … │ [101, 1…\n        ⋮ │ ⋮\n [1, 2, … │ [101, 1…\n [1, 2, … │ [101, 1…"
     else
-        @test show_str(Dictionary{Vector{Int64},Vector{Int64}}([collect(1:100+i) for i in 1:100],[collect(101:200+i) for i in 1:100])) == "100-element Dictionary{Vector{Int64}, Vector{Int64}}\n Int64[1… │ Int64[1…\n Int64[1… │ Int64[1…\n Int64[1… │ Int64[1…\n        ⋮ │ ⋮\n Int64[1… │ Int64[1…\n Int64[1… │ Int64[1…"
+        @test show_str(Dictionary{Vector{Int64},Vector{Int64}}([collect(1:100+i) for i in 1:100],[collect(101:200+i) for i in 1:100])) == "100-element Dictionary{Vector{Int64}, Vector{Int64}}:\n Int64[1… │ Int64[1…\n Int64[1… │ Int64[1…\n Int64[1… │ Int64[1…\n        ⋮ │ ⋮\n Int64[1… │ Int64[1…\n Int64[1… │ Int64[1…"
     end
 end


### PR DESCRIPTION
Hi, I noticed some slight inconsistencies with the way things are printed here and typical arrays. I was wondering if you would be interested in the following changes:
---

I added a colon after the summary in the display. This is more in line with `Base.AbstractArray` and `Base.AbstractDict` implementations. It doesn't matter to much, but I think it looks slightly nicer with that addition
```julia
# before
1-element Dictionary{String, String}
 "test" │ "something"
# after
1-element Dictionary{String, String}:
 "test" │ "something"
```

---

I added a `summary` implementation to include the size information (whenever available)
```julia
# before
Dictionary{String, String}
# after
1-element Dictionary{String, String}
```

Feel free to let me know what you think about these changes, or would like for me to make some other changes.

---

Aside from this, I noted that `AbstractDict` has the following summary implementation:
```julia
function summary(io::IO, t::AbstractDict)
    showarg(io, t, true)
    if Base.IteratorSize(t) isa HasLength
        n = length(t)
        print(io, " with ", n, (n==1 ? " entry" : " entries"))
    else
        print(io, "(...)")
    end
end
```
I wanted to know if you have any opinions on adding some form of `(...)`, or `?-element` to indicate an unknown length summary.

In any case, awesome package, thanks for that!