### PR TITLE
Fix method invalidations

### DIFF
--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -4,6 +4,7 @@ struct ReverseIndices{I, Inds <: AbstractIndices{I}} <: AbstractIndices{I}
 end
 
 Base.parent(inds::ReverseIndices) = getfield(inds, :inds)
+@propagate_inbounds Base.in(item, inds::ReverseIndices) = in(item, parent(inds))
 Base.length(inds::ReverseIndices) = length(parent(inds))
 Base.IteratorSize(inds::ReverseIndices) = Base.IteratorSize(parent(inds))
 

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -4,7 +4,6 @@ struct ReverseIndices{I, Inds <: AbstractIndices{I}} <: AbstractIndices{I}
 end
 
 Base.parent(inds::ReverseIndices) = getfield(inds, :inds)
-@propagate_inbounds Base.in(inds::ReverseIndices{I}, i::I) where {I} = in(parent(inds), i)
 Base.length(inds::ReverseIndices) = length(parent(inds))
 Base.IteratorSize(inds::ReverseIndices) = Base.IteratorSize(parent(inds))
 


### PR DESCRIPTION
This is a PR to attempt to fix #147

The invalidating code is indeed the definition of `in` for the reverse indices, and I tried digging around to find out what this method is supposed to do, but I got lost a bit.

From what I understand, `Base.in(item, collection)` is usually defined with untyped `item`, specializing on the collection.
However, here there is a specific implementation for `Base.in(item::ReverseIndices, collection::AbstractIndices)`, and I'm actually failing to see what this method is supposed to accomplish.
Somehow, this is mapping to a function where `in(item::I, collection::I)` is the result, so the item is of the same type as the collection, where I would have expected the item to be of the `eltype` of the collection.
I might be fully missing something here, but is it possible this is just some legacy thing that is never actually being called?

In any case, simply removing this method fixes all invalidations while still letting the tests pass.
In particular, I noted that `Base.in(item, inds::ReverseIndices)` definitely already works because it subtypes `AbstractIndices` and implements the required methods.
Otherwise, if you could maybe explain to me what I'm missing I'm more than happy to add some tests to capture this as well, and I'll try come up with a different attempt of fixing #147.

<details>
<summary>Current master + julia 1.11</summary>

```julia
using SnoopCompileCore
invs = @snoop_invalidations using Dictionaries
using SnoopCompile

julia> trees = invalidation_trees(invs)
1-element Vector{SnoopCompile.MethodInvalidations}:
 inserting in(inds::ReverseIndices{I, Inds} where Inds<:AbstractIndices{I}, i::I) where I @ Dictionaries ~/Projects/BugFixes/CatCompilation/dev/Dictionaries/src/reverse.jl:7 invalidated:
   backedges:  1: superseding in(key, v::Base.KeySet{<:Any, <:Dict}) @ Base dict.jl:549 with MethodInstance for in(::Any, ::Base.KeySet{String, Dict{String, Set{Any}}}) (1 children)
               2: superseding in(x, itr::Tuple) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::Tuple{Symbol, Symbol}) (1 children)
               3: superseding in(x, itr::Tuple) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::NTuple{5, Symbol}) (1 children)
               4: superseding in(x, itr) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::String) (1 children)
               5: superseding in(x, s::Set) @ Base set.jl:92 with MethodInstance for in(::Any, ::Set{Base.PkgId}) (2 children)
               6: superseding in(x, itr::Tuple) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::NTuple{6, Char}) (2 children)
               7: superseding in(x, itr::Tuple) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::Tuple{String, String, String}) (2 children)
               8: superseding in(x, itr::Tuple) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::NTuple{11, Char}) (5 children)
               9: superseding in(x, itr::Tuple) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::Tuple{Char, Char, Char}) (5 children)
              10: superseding in(x, itr::Tuple) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::Tuple{Char, Char}) (7 children)
              11: superseding in(x, itr::Tuple) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::NTuple{4, Char}) (14 children)
              12: superseding in(x, itr) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::Vector{String}) (17 children)
              13: superseding in(x, itr::Tuple) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::Tuple{Nothing, Bool}) (20 children)
              14: superseding in(x, itr) @ Base operators.jl:1302 with MethodInstance for in(::Any, ::BitSet) (64 children)
              15: superseding in(k, v::Base.KeySet{<:Any, <:IdDict}) @ Base iddict.jl:182 with MethodInstance for in(::Any, ::Base.KeySet{Any, IdDict{Any, Any}}) (115 children)
   5 mt_cache
```

</details>

<details>
<summary>After PR + Julia 1.11</summary>

```julia
using SnoopCompileCore
invs = @snoop_invalidations using Dictionaries
using SnoopCompile
julia> trees = invalidation_trees(invs)
SnoopCompile.MethodInvalidations}[]
```

</details>