### PR TITLE
Fix bug in `gettoken` when first argument is of type `FilteredIndices`

### DIFF
--- a/src/filter.jl
+++ b/src/filter.jl
@@ -86,7 +86,7 @@ end
 @propagate_inbounds function gettoken(inds::FilteredIndices, i)
     (hastoken, token) = gettoken(parent(inds), i)
     @boundscheck if hastoken
-        return (_pred(inds)(@inbounds gettokenvalue(parent, token)), token)
+        return (_pred(inds)(@inbounds gettokenvalue(parent(inds), token)), token)
     end
     return (hastoken, token)
 end

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -11,6 +11,9 @@
     @test_throws IndexError filterview(isodd, inds)[2]
     @test in(2, filterview(iseven, inds))
     @test !in(2, filterview(isodd, inds))
+    @test first(gettoken(filterview(iseven, inds), 2))
+    @test first(gettoken(filterview(isodd, inds), 3))
+    @test !first(gettoken(filterview(isodd, inds), 2))
 
     @test collect(reverse(filterview(iseven, inds))) == [4, 2]
 


### PR DESCRIPTION
Previously, would error due to passing the function `parent` itself as an argument to a function call, rather than `parent(inds)`.

Added some tests for this particular method.